### PR TITLE
fix(monitoring): resolve false KubeletDown alert (cluster label join)

### DIFF
--- a/kubernetes/apps/pitower/monitoring/kube-prometheus-stack/values.yaml
+++ b/kubernetes/apps/pitower/monitoring/kube-prometheus-stack/values.yaml
@@ -67,6 +67,18 @@ kube-state-metrics:
 kubelet:
   enabled: true
   serviceMonitor:
+    # Stamp the cluster label so the KubeletDown rule's join matches:
+    #   count by (cluster) (kube_node_info)
+    #   unless on (cluster) count by (cluster) (up{job="kubelet"} == 1)
+    # kube_node_info carries cluster="pitower" (from a metric relabeling) but the
+    # synthetic `up` series does not. `up` is appended after metric_relabel_configs
+    # run, so it can only gain the label via target relabeling (relabelings),
+    # not metricRelabelings. Without it the join never cancels and KubeletDown
+    # fires permanently even though every kubelet is up.
+    relabelings:
+      - action: replace
+        targetLabel: cluster
+        replacement: pitower
     metricRelabelings:
       # Remove duplicate labels provided by k3s
       - action: keep


### PR DESCRIPTION
## Problem

`KubeletDown` (severity: critical) has fired continuously since **2026-05-25 ~01:43 UTC** even though all 6 kubelets are healthy and being scraped (`up{job="kubelet"} == 1` on every node across `/metrics`, `/metrics/cadvisor`, `/metrics/probes`).

## Root cause

The vendored kube-prometheus-stack rule is a label join, not a simple up check:

```promql
count by (cluster) (kube_node_info{job="kube-state-metrics"})
unless on (cluster)
count by (cluster) (up{job="kubelet", metrics_path="/metrics"} == 1)
for: 15m
```

Inspecting the live rendered Prometheus config: every scrape job stamps `cluster=pitower`, but it lives in **`metric_relabel_configs`**, which only runs on scraped samples. The synthetic `up` series is generated by Prometheus *after* metric relabeling, so it never gets `cluster`. (The global `external_labels: cluster: pitower` only attaches on remote_write/alerting, not local TSDB queries.)

Result: `kube_node_info` has `cluster="pitower"`, `up{job="kubelet"}` has none → `unless on (cluster)` never cancels → all nodes report as kubelet-down → permanent false alert.

It routes to the `null` receiver, so it has been red in Alertmanager for ~5 days without paging via ntfy.

## Fix

Add a `relabelings` entry (target relabeling, which *does* apply to `up`) on the kubelet ServiceMonitor stamping `cluster=pitower`. The chart applies `serviceMonitor.relabelings` to the main `/metrics` endpoint — which is exactly the one the alert filters on (`metrics_path="/metrics"`) — so `up{job="kubelet", metrics_path="/metrics"}` now carries `cluster` and matches `kube_node_info` on the join.

## Verification

`kustomize build --enable-helm` renders the `kube-prometheus-stack-kubelet` ServiceMonitor with the `/metrics` endpoint now carrying a `relabelings` entry `targetLabel: cluster / replacement: pitower`. The alert should resolve within the `15m` `for:` window after ArgoCD syncs and Prometheus reloads.