### PR TITLE
feat(monitoring): bump Grafana to v13 (grafana-community chart 12.4.1)

### DIFF
--- a/kubernetes/apps/pitower/monitoring/grafana/kustomization.yaml
+++ b/kubernetes/apps/pitower/monitoring/grafana/kustomization.yaml
@@ -41,8 +41,8 @@ configMapGenerator:
 
 helmCharts:
   - name: grafana
-    repo: https://grafana.github.io/helm-charts
-    version: 10.5.15
+    repo: https://grafana-community.github.io/helm-charts
+    version: 12.4.1
     releaseName: grafana
     namespace: monitoring
     valuesFile: values.yaml


### PR DESCRIPTION
## What

Bumps the standalone Grafana app from Grafana **12.3.1** to **13.0.1-security-01** by switching to the grafana-community Helm chart.

| | before | after |
|---|---|---|
| repo | `grafana.github.io/helm-charts` | `grafana-community.github.io/helm-charts` |
| chart | `10.5.15` | `12.4.1` |
| Grafana appVersion | 12.3.1 | 13.0.1-security-01 |

## Why switch repos

The official `grafana/helm-charts` grafana chart is **deprecated** and its version line stalled at `10.5.x` (Grafana 12.3.1). The grafana-community fork is the maintained successor and publishes chart `12.4.1` shipping Grafana 13.0.1-security-01.

## Changes

- `kustomization.yaml`: repo URL + chart version only. `charts/` is gitignored and re-pulled at render time, so ArgoCD fetches the new chart fresh.

## Verification

`kustomize build --enable-helm` renders cleanly with the existing `values.yaml` and the Deployment now references `docker.io/grafana/grafana:13.0.1-security-01`.

## Note

Grafana 13 is a major version bump — worth reviewing the [breaking changes](https://grafana.com/docs/grafana/latest/whatsnew/) (dashboard schema, Angular plugin removal, deprecated panels) before/after rollout. No values changes were required for the render to succeed.