### PR TITLE
feat(ack): AWS ACK controllers via dedicated ApplicationSet + shared IRSA role

### DIFF
--- a/kubernetes/argocd/ack-applicationset.yaml
+++ b/kubernetes/argocd/ack-applicationset.yaml
@@ -1,0 +1,170 @@
+---
+# Dedicated ApplicationSet for AWS Controllers for Kubernetes (ACK).
+#
+# Separate from the unified `home-ops` ApplicationSet (./applicationset.yaml)
+# because ACK can't go through that AppSet's git-directory + kustomize render
+# path: the umbrella `ack-chart` ships the shared common CRDs (adoptedresources,
+# fieldexports, iamroleselectors) once per enabled subchart, and
+# `kustomize build --enable-helm` hard-errors on the duplicate resource IDs
+# (ACK community #2018). ArgoCD's NATIVE Helm source + ServerSideApply applies
+# them cleanly, so this AppSet uses a Helm source directly.
+#
+# A clusters generator selects ONLY pitower (label home-ops/cluster: pitower on
+# its cluster Secret) and deploys to {{.server}} — generated app: `pitower-ack`.
+#
+# All controllers share ONE IRSA role (pitower-ack-controllers, defined in
+# terraform/general/ack.tf). Each subchart's ServiceAccount is
+# ack-<svc>-controller in ack-system, matched by the role trust policy
+# StringLike `system:serviceaccount:ack-system:ack-*-controller`.
+#
+# Applied MANUALLY (like ./applicationset.yaml) — not managed by ArgoCD:
+#   kubectl apply -f kubernetes/argocd/ack-applicationset.yaml
+# NOTE: the chart version (targetRevision) is baked into this template, so a
+# version bump requires re-applying this file (Renovate edits it, but the
+# generated Application only picks it up on re-apply).
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: ack
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            home-ops/cluster: pitower
+  template:
+    metadata:
+      name: "{{.name}}-ack"
+      namespace: argocd
+      labels:
+        app.kubernetes.io/name: ack
+        app.kubernetes.io/managed-by: argocd
+        home-ops/cluster: "{{.name}}"
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      project: apps
+      source:
+        repoURL: public.ecr.aws/aws-controllers-k8s
+        chart: ack-chart
+        targetRevision: 46.113.0
+        helm:
+          releaseName: ack
+          # Each controller is a subchart toggled by `<svc>.enabled`; all share
+          # the eu-central-2 region and the single IRSA role above. Add a
+          # controller by appending the same block AND extending the IAM policy
+          # in ack.tf.
+          values: |
+            acm:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            cloudfront:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            dynamodb:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            ec2:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            elbv2:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            iam:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            kms:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            rds:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            route53:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            s3:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            secretsmanager:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            sns:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+            sqs:
+              enabled: true
+              aws:
+                region: eu-central-2
+              serviceAccount:
+                annotations:
+                  eks.amazonaws.com/role-arn: arn:aws:iam::633355703129:role/pitower-ack-controllers
+      destination:
+        server: "{{.server}}"
+        namespace: ack-system
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: false
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - SkipDryRunOnMissingResource=true
+          - ApplyOutOfSyncOnly=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+      revisionHistoryLimit: 3

--- a/kubernetes/bootstrap/appproject.yaml
+++ b/kubernetes/bootstrap/appproject.yaml
@@ -9,6 +9,8 @@ spec:
   description: Apps
   sourceRepos:
     - https://github.com/swibrow/home-ops
+    # ACK umbrella chart (app-ack.yaml) — OCI Helm registry
+    - public.ecr.aws/aws-controllers-k8s
   destinations:
     - namespace: "*"
       name: "*"

--- a/terraform/general/ack.tf
+++ b/terraform/general/ack.tf
@@ -1,0 +1,91 @@
+################################################################################
+# Shared IRSA role for the AWS Controllers for Kubernetes (ACK) controllers.
+#
+# A single "admin-ish" role assumed by every ACK controller running in the
+# `ack-system` namespace on pitower (deployed via the ack-chart umbrella at
+# kubernetes/apps/pitower/ack-system/ack-controllers). Each controller's
+# ServiceAccount is named `ack-<service>-controller`; the trust policy below
+# uses a StringLike on the OIDC `sub` so ONLY those controller ServiceAccounts
+# can assume the role — nothing else in the cluster, and no human/GitHub path.
+#
+# The OIDC provider is created in terraform/bootstrap and looked up via the
+# shared data source in volsync.tf.
+#
+# BLAST RADIUS: the permissions policy is broad (service-wildcard on the set of
+# services we run controllers for, INCLUDING iam:*). iam:* means a compromised
+# iam-controller could create privileged roles. This is the price of running the
+# ACK iam-controller; tighten to specific actions/resources if that tradeoff
+# stops being acceptable.
+################################################################################
+
+resource "aws_iam_role" "ack_controllers" {
+  name = "${local.name}-ack-controllers"
+  tags = local.tags
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Federated = data.aws_iam_openid_connect_provider.kubernetes.arn }
+        Action    = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(data.aws_iam_openid_connect_provider.kubernetes.url, "https://", "")}:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "${replace(data.aws_iam_openid_connect_provider.kubernetes.url, "https://", "")}:sub" = "system:serviceaccount:ack-system:ack-*-controller"
+          }
+        }
+      },
+    ]
+  })
+}
+
+# Broad, service-scoped permissions for the controllers we enable. This is
+# deliberately wide ("create most things") but limited to the AWS services we
+# actually run controllers for, rather than AdministratorAccess.
+resource "aws_iam_role_policy" "ack_controllers" {
+  name = "${local.name}-ack-controllers"
+  role = aws_iam_role.ack_controllers.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AckServiceAccess"
+        Effect = "Allow"
+        Action = [
+          "ec2:*",
+          "route53:*",
+          "iam:*",
+          "s3:*",
+          "dynamodb:*",
+          "rds:*",
+          "cloudfront:*",
+          "acm:*",
+          "elasticloadbalancing:*",
+          "sqs:*",
+          "sns:*",
+          "secretsmanager:*",
+          "kms:*",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AckTagging"
+        Effect = "Allow"
+        Action = [
+          "tag:GetResources",
+          "tag:TagResources",
+          "tag:UntagResources",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+output "ack_controllers_role_arn" {
+  value = aws_iam_role.ack_controllers.arn
+}


### PR DESCRIPTION
Adds 13 AWS Controllers for Kubernetes (ACK) controllers on pitower from the umbrella `ack-chart`: **acm, cloudfront, dynamodb, ec2, elbv2, iam, kms, rds, route53, s3, secretsmanager, sns, sqs**.

## What's here

- **`terraform/general/ack.tf`** — one shared IRSA role `pitower-ack-controllers`, OIDC-trusted **only** by `system:serviceaccount:ack-system:ack-*-controller` (nothing else can assume it). Broad but service-scoped policy across exactly the services above (not `AdministratorAccess`).
- **`kubernetes/argocd/ack-applicationset.yaml`** — dedicated ApplicationSet, clusters generator pinned to pitower (`home-ops/cluster: pitower`), native ArgoCD Helm source, 13 controllers enabled inline. Generated app: `pitower-ack`.
- **`kubernetes/bootstrap/appproject.yaml`** — allow the `public.ecr.aws/aws-controllers-k8s` OCI registry in the `apps` AppProject.

## Why a dedicated ApplicationSet (not a kustomize app dir)

The umbrella ships the shared common CRDs (`adoptedresources`, `fieldexports`, `iamroleselectors`) once per enabled subchart. `kustomize build --enable-helm` — the normal `kubernetes/apps/*/*` render path — hard-errors on the duplicate resource IDs ([ACK community #2018](https://github.com/aws-controllers-k8s/community/issues/2018), unresolved). ArgoCD's **native Helm source + `ServerSideApply`** applies them cleanly, so ACK uses a Helm source directly.

## Deploy

1. Merge → `terraform-apply` CI creates the IAM role.
2. Apply the AppSet (manual, like `applicationset.yaml`):
   ```
   kubectl --context=admin@pitower apply -f kubernetes/argocd/ack-applicationset.yaml
   ```

## Notes

- `iam:*` is in the policy (the iam-controller needs it) — flagged as blast radius in `ack.tf`.
- Chart version (`targetRevision: 46.113.0`) is baked into the AppSet template, so a Renovate bump needs the AppSet re-applied to take effect.
- `selfHeal: false` to match the pitower convention.