### PR TITLE
feat: bootstrap controller+auth platform; prepare hub-spoke ApplicationSet

### DIFF
--- a/kubernetes/apps/_base/kube-system/coredns/values.yaml
+++ b/kubernetes/apps/_base/kube-system/coredns/values.yaml
@@ -1,0 +1,59 @@
+---
+# Shared CoreDNS base values, reused by every cluster's overlay via the chart's
+# `valuesFile`. Per-cluster overlays layer their diffs through
+# `additionalValuesFiles` (later files win; lists are replaced, not merged).
+#
+# `_base` is never a cluster name, so the cluster-selector ApplicationSet
+# (kubernetes/argocd/applicationset.yaml, path kubernetes/apps/{{.name}}/*/*)
+# never scans this directory.
+fullnameOverride: coredns
+image:
+  repository: mirror.gcr.io/coredns/coredns
+k8sAppLabelOverride: kube-dns
+serviceAccount:
+  create: true
+service:
+  name: kube-dns
+  clusterIP: 10.96.0.10
+servers:
+  - zones:
+      - zone: .
+        scheme: dns://
+        use_tcp: true
+    port: 53
+    plugins:
+      - name: errors
+      - name: health
+        configBlock: |-
+          lameduck 5s
+      - name: ready
+      - name: log
+        configBlock: |-
+          class error
+      - name: prometheus
+        parameters: 0.0.0.0:9153
+      - name: kubernetes
+        parameters: cluster.local in-addr.arpa ip6.arpa
+        configBlock: |-
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+      - name: forward
+        parameters: . /etc/resolv.conf
+      - name: cache
+        parameters: 30
+      - name: loop
+      - name: reload
+      - name: loadbalance
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule

--- a/kubernetes/apps/_base/security/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/_base/security/external-secrets/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+resources:
+  - operator
+  - stores

--- a/kubernetes/apps/_base/security/external-secrets/operator/kustomization.yaml
+++ b/kubernetes/apps/_base/security/external-secrets/operator/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+
+helmCharts:
+  - name: external-secrets
+    repo: https://charts.external-secrets.io/
+    version: 2.6.0
+    releaseName: external-secrets
+    namespace: security
+    valuesFile: values.yaml
+    includeCRDs: true

--- a/kubernetes/apps/_base/security/external-secrets/operator/values.yaml
+++ b/kubernetes/apps/_base/security/external-secrets/operator/values.yaml
@@ -1,0 +1,19 @@
+installCRDs: true
+replicaCount: 1
+leaderElect: true
+# controller has no kube-prometheus-stack / Grafana — leave ServiceMonitors and
+# the Grafana dashboard off so the chart doesn't emit monitoring.coreos.com
+# resources whose CRDs don't exist on this cluster.
+grafana:
+  enabled: false
+serviceMonitor:
+  enabled: false
+backgroundController:
+  serviceMonitor:
+    enabled: false
+cleanupController:
+  serviceMonitor:
+    enabled: false
+reportsController:
+  serviceMonitor:
+    enabled: false

--- a/kubernetes/apps/_base/security/external-secrets/stores/infisical/clustersecretstore.yaml
+++ b/kubernetes/apps/_base/security/external-secrets/stores/infisical/clustersecretstore.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: infisical
+spec:
+  provider:
+    infisical:
+      hostAPI: https://eu.infisical.com
+      auth:
+        universalAuthCredentials:
+          clientId:
+            key: clientId
+            namespace: security
+            name: universal-auth-credentials
+          clientSecret:
+            key: clientSecret
+            namespace: security
+            name: universal-auth-credentials
+      secretsScope:
+        projectSlug: home-lab-iwi-y
+        environmentSlug: prod
+        secretsPath: /
+        recursive: true
+        expandSecretReferences: false

--- a/kubernetes/apps/_base/security/external-secrets/stores/infisical/kustomization.yaml
+++ b/kubernetes/apps/_base/security/external-secrets/stores/infisical/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+resources:
+  - ./clustersecretstore.yaml
+labels:
+  - pairs:
+      app.kubernetes.io/name: stores
+      app.kubernetes.io/instance: infisical
+      app.kubernetes.io/part-of: external-secrets

--- a/kubernetes/apps/_base/security/external-secrets/stores/infisical/secret.sops.yaml
+++ b/kubernetes/apps/_base/security/external-secrets/stores/infisical/secret.sops.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: universal-auth-credentials
+type: Opaque
+stringData:
+    clientId: ENC[AES256_GCM,data:3410f/vLpRk707C9dahPFaUTfLhVgbonVL0ECFFySnDDsATB,iv:1k6X6M7KOpqDbxzRdCQ2bT0SR70iui67n/WvnpRdFSk=,tag:JXDoPBb4+AJc+yv41PmpzQ==,type:str]
+    clientSecret: ENC[AES256_GCM,data:i/7SOweDGWFOOV4m8730i6d4NnxDRH737+B3oI0lg7BXJGNDffU6FZBw0vbkEfr0HNaw6b6PbHvp3w7pHHOXHg==,iv:+lpUL6+SRmQgXCzaWCknsiz8EbBzizA6xqdv8wjJLtI=,tag:1DLLB3f5dYUxBgVdfmeaIg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1tkaddc3hgjx0eagjl6mqpxvzzkerd44e34rua6gzucv6emr5f5fs4mlu67
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQQU1ZdXREaVplTUw2RlJE
+            eTBLaXEzL0ZQZkxlVldaVERHU0Z6VXAvSlRBCk1RTnhOZkRpZGl0cm54VnlCa3Jh
+            Yks3bVNKYzJzZ0VPbFNDRldsOWExLzAKLS0tIGE4NGVoOU1FL29BbWhCNHh1VjI2
+            RTc0MkJhcGFOWUVpcng1U21raTF1akUK7CBomHy2rO+7asmXhpVbvtrM7p3rIaUb
+            qRwi6ukklI7drInA97+WPX9TP6dtlHBnOSufDEN/KzJAc8yOsbcUDg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-05-25T20:19:59Z"
+    mac: ENC[AES256_GCM,data:6qJpr45czaJ5dfi/Bw0oM1SkzHd+MUvikCtEsWwjkPUPA6U3RRuG+SyYTjpohIvvMaceZIyXbBB/fnXvmOKA97lw21VqHzIu6NH26fWHlF8f4OwLo+6he1UpCPETfwB2JydM7yVa1RcraWSqFFk1wJvdCu5wMnc5R0qu5+0Hqjg=,iv:vnEZxltyM+5gAG9jrOtiyAmM2yN4ze0sI8VmdoOjgzc=,tag:/GVxIf4ODIiYWZyy3Z/aAg==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.9.1

--- a/kubernetes/apps/_base/security/external-secrets/stores/kustomization.yaml
+++ b/kubernetes/apps/_base/security/external-secrets/stores/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./infisical

--- a/kubernetes/apps/auth/kube-system/coredns/kustomization.yaml
+++ b/kubernetes/apps/auth/kube-system/coredns/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+
+helmCharts:
+  - name: coredns
+    repo: https://coredns.github.io/helm
+    version: 1.46.0
+    releaseName: coredns
+    namespace: kube-system
+    # Shared base values + this cluster's overlay (later file wins).
+    valuesFile: ../../../_base/kube-system/coredns/values.yaml
+    additionalValuesFiles:
+      - values.yaml

--- a/kubernetes/apps/auth/kube-system/coredns/values.yaml
+++ b/kubernetes/apps/auth/kube-system/coredns/values.yaml
@@ -1,0 +1,4 @@
+---
+# auth (single-node) overlay — only the diffs from _base/kube-system/coredns.
+# One replica, no hostname topologySpread (single node).
+replicaCount: 1

--- a/kubernetes/apps/auth/security/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/auth/security/external-secrets/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# auth overlay — consumes the shared external-secrets base verbatim (same as
+# controller). The Infisical machine-identity secret (universal-auth-credentials)
+# is applied manually from
+# _base/security/external-secrets/stores/infisical/secret.sops.yaml.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+resources:
+  - ../../../_base/security/external-secrets

--- a/kubernetes/apps/controller/kube-system/coredns/kustomization.yaml
+++ b/kubernetes/apps/controller/kube-system/coredns/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+
+helmCharts:
+  - name: coredns
+    repo: https://coredns.github.io/helm
+    version: 1.46.0
+    releaseName: coredns
+    namespace: kube-system
+    # Shared base values + this cluster's overlay (later file wins).
+    valuesFile: ../../../_base/kube-system/coredns/values.yaml
+    additionalValuesFiles:
+      - values.yaml

--- a/kubernetes/apps/controller/kube-system/coredns/values.yaml
+++ b/kubernetes/apps/controller/kube-system/coredns/values.yaml
@@ -1,0 +1,5 @@
+---
+# controller (single-node) overlay — only the diffs from _base/kube-system/coredns.
+# One replica, and no hostname topologySpread (a 2nd replica could never schedule
+# on a one-node cluster and would sit Pending forever).
+replicaCount: 1

--- a/kubernetes/apps/controller/security/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/controller/security/external-secrets/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# controller overlay — external-secrets is identical across the management
+# clusters (no Prometheus, so the base already has serviceMonitor/grafana off),
+# so this just consumes the shared base verbatim. No per-cluster values needed.
+#
+# The Infisical machine-identity secret (universal-auth-credentials) is applied
+# manually from _base/security/external-secrets/stores/infisical/secret.sops.yaml.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+resources:
+  - ../../../_base/security/external-secrets

--- a/kubernetes/argocd/applicationset.yaml
+++ b/kubernetes/argocd/applicationset.yaml
@@ -1,0 +1,94 @@
+---
+# Unified, cluster-selector-driven ApplicationSet (hub-spoke).
+#
+# Supersedes the per-cluster ApplicationSets in ./clusters/*.yaml once ArgoCD
+# has moved to the `controller` hub. A single matrix generator:
+#
+#   1. clusters generator (PRODUCER) — selects every registered ArgoCD cluster
+#      Secret carrying `home-ops/managed: "true"`, exposing {{.name}} / {{.server}}.
+#   2. git directories generator (CONSUMER) — scans ONLY that cluster's app tree
+#      via `kubernetes/apps/{{.name}}/*/*`. Because {{.name}} comes from the
+#      producer, each cluster scans just its own dirs — no cluster×app cross
+#      product. (Matrix rule: the consumer generator must come AFTER the producer.)
+#
+# Apps then deploy to `{{.server}}` (the selected cluster's API), so the same
+# AppSet drives the hub (controller, in-cluster) and every spoke (pitower, …).
+#
+# REQUIRED cluster-Secret convention (in the argocd namespace, self-managed by
+# the controller ArgoCD bootstrap):
+#   labels:
+#     argocd.argoproj.io/secret-type: cluster
+#     home-ops/managed: "true"          # <- selected by this AppSet
+#   stringData:
+#     name: <cluster>                    # MUST match the dir under kubernetes/apps/<cluster>
+#     server: <api>                      # hub: https://kubernetes.default.svc | spoke: https://<vip>:6443
+#     config: { … bearerToken/CA for spokes … }
+#
+# Applied MANUALLY (like the per-cluster files) — not managed by ArgoCD — to
+# avoid an AppSet managing the AppSet:  kubectl apply -f kubernetes/argocd/applicationset.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: home-ops
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - matrix:
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  home-ops/managed: "true"
+          - git:
+              repoURL: https://github.com/swibrow/home-ops
+              revision: main
+              directories:
+                - path: kubernetes/apps/{{.name}}/*/*
+  template:
+    metadata:
+      name: "{{.name}}-{{index .path.segments 3}}-{{index .path.segments 4}}"
+      namespace: argocd
+      labels:
+        app.kubernetes.io/name: "{{index .path.segments 4}}"
+        app.kubernetes.io/instance: "{{.name}}-{{index .path.segments 3}}-{{index .path.segments 4}}"
+        app.kubernetes.io/component: "{{index .path.segments 3}}"
+        app.kubernetes.io/part-of: "{{.name}}"
+        app.kubernetes.io/managed-by: argocd
+        home-ops/cluster: "{{.name}}"
+        home-ops/category: "{{index .path.segments 3}}"
+        home-ops/namespace: "{{index .path.segments 3}}"
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      project: apps
+      source:
+        repoURL: https://github.com/swibrow/home-ops
+        targetRevision: main
+        path: "{{.path.path}}"
+      destination:
+        server: "{{.server}}"
+        namespace: "{{index .path.segments 3}}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: false
+        managedNamespaceMetadata:
+          labels:
+            pod-security.kubernetes.io/enforce: privileged
+            pod-security.kubernetes.io/audit: privileged
+            pod-security.kubernetes.io/warn: privileged
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - SkipDryRunOnMissingResource=true
+          - ApplyOutOfSyncOnly=true
+          - Timeout=600
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+      revisionHistoryLimit: 3

--- a/kubernetes/argocd/cluster-secrets/controller.yaml
+++ b/kubernetes/argocd/cluster-secrets/controller.yaml
@@ -1,0 +1,29 @@
+---
+# Hub cluster registration (controller — where ArgoCD itself runs).
+#
+# Points at the local API, so apps under kubernetes/apps/controller/*/* deploy
+# in-cluster. The `home-ops/managed` label is what the unified ApplicationSet
+# (../applicationset.yaml) selects on; `name: controller` MUST match the
+# directory under kubernetes/apps/<cluster>.
+#
+# Prepared for cutover — apply (or fold into the controller ArgoCD bootstrap)
+# once ArgoCD runs on controller. No credentials needed for the local cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: controller-cluster
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    home-ops/managed: "true"
+    home-ops/cluster: controller
+type: Opaque
+stringData:
+  name: controller
+  server: https://kubernetes.default.svc
+  config: |
+    {
+      "tlsClientConfig": {
+        "insecure": false
+      }
+    }

--- a/kubernetes/argocd/cluster-secrets/pitower.yaml
+++ b/kubernetes/argocd/cluster-secrets/pitower.yaml
@@ -1,0 +1,54 @@
+---
+# Spoke cluster registration (pitower — managed remotely by the controller hub).
+#
+# The bearer token + CA are pulled from Infisical via ESO and templated into the
+# ArgoCD cluster Secret, so no credential lands in git. The `home-ops/managed`
+# label is what ../applicationset.yaml selects on; `name: pitower` MUST match the
+# directory under kubernetes/apps/pitower.
+#
+# CUTOVER PREREQUISITES (do these first, then apply this file):
+#   1. On pitower, create a least-privilege (or cluster-admin) ServiceAccount
+#      `argocd-manager` (kube-system) + ClusterRoleBinding + a long-lived
+#      ServiceAccount token Secret. See cluster-rbac on pitower.
+#   2. Store that token and the pitower API CA (base64) in Infisical at
+#      /argocd/clusters/pitower/{bearerToken,caData}.
+#   3. server below is the pitower API VIP (10.20.10.0); confirm reachability
+#      from controller (VLAN 20) before cutover.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pitower-cluster
+  namespace: argocd
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: pitower-cluster
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          home-ops/managed: "true"
+          home-ops/cluster: pitower
+      data:
+        name: pitower
+        server: https://10.20.10.0:6443
+        config: |
+          {
+            "bearerToken": "{{ .bearerToken }}",
+            "tlsClientConfig": {
+              "insecure": false,
+              "caData": "{{ .caData }}"
+            }
+          }
+  data:
+    - secretKey: bearerToken
+      remoteRef:
+        key: /argocd/clusters/pitower/bearerToken
+    - secretKey: caData
+      remoteRef:
+        key: /argocd/clusters/pitower/caData


### PR DESCRIPTION
## Summary

First steps of moving ArgoCD to the `controller` hub (hub-spoke), validated **without touching pitower**. Brings the two bare single-node management clusters (`controller`, `auth`) to platform baseline using **shared kustomize bases**, and prepares the unified cluster-selector ApplicationSet for cutover.

Everything here is already **applied manually** to `controller` and `auth` and verified working; the repo files are so a future controller-hosted ArgoCD adopts them with zero churn.

## What's included

### Shared bases (`kubernetes/apps/_base/`)
`_base` is never a cluster name, so the cluster-selector ApplicationSet (`kubernetes/apps/{{.name}}/*/*`) never scans it.

- **`_base/kube-system/coredns`** — shared CoreDNS values. Management clusters disable Talos' built-in CoreDNS, so DNS must be deployed here; without it **all pod DNS times out** (root cause we hit on controller). Per-cluster overlays layer `replicaCount: 1` (single node) via `additionalValuesFiles` (value-layering pattern).
- **`_base/security/external-secrets`** — ESO 2.6.0 + Infisical `ClusterSecretStore`, `serviceMonitor`/`grafana` off (no Prometheus on mgmt clusters). `controller`/`auth` consume it verbatim via `resources: [_base]` (full-base pattern). The Infisical machine-identity secret stays out of kustomize and is applied manually via `sops`.

### Per-cluster overlays
- `controller/{kube-system/coredns, security/external-secrets}`
- `auth/{kube-system/coredns, security/external-secrets}`

Renders verified **byte-identical** controller↔auth (and controller unchanged vs its earlier standalone form → zero churn).

### Hub-spoke ApplicationSet (prepared, not yet applied)
- **`argocd/applicationset.yaml`** — single matrix ApplicationSet (`clusters` generator → `git` directories `kubernetes/apps/{{.name}}/*/*`). Producer-first ordering scopes the git path per selected cluster (no cluster×app cross-product); apps deploy to `{{.server}}`. Supersedes the per-cluster AppSets at cutover.
- **`argocd/cluster-secrets/{controller,pitower}.yaml`** — the cluster-Secret convention it selects on (`home-ops/managed: "true"`). Controller = hub (in-cluster); pitower = spoke via ExternalSecret (bearer token pulled from Infisical, never in git).

## Live validation
Both clusters: CoreDNS + ESO running, Infisical `ClusterSecretStore` **Valid/Ready**, a real secret synced. `auth` came up first-try by applying **DNS-first**.

## Not in this PR (deliberate)
- **pitower** — untouched.
- ArgoCD-on-controller itself, the remote `argocd-manager` SA/token on pitower, and the ACK ApplicationSet — follow-ups.

## Notes for reviewers
- AppSets and cluster-secrets are applied **manually** by convention; nothing here auto-syncs. The live `clusters/pitower.yaml` keeps running until cutover.
- Vendored Helm `charts/` are gitignored as usual.