### PR TITLE
feat(homeassistant): add water schedule blueprint for Sonoff valve

### DIFF
--- a/iot/CLAUDE.md
+++ b/iot/CLAUDE.md
@@ -74,3 +74,18 @@ Run custom actions when motion is detected. Supports multiple motion sensors and
 - Triggers when any sensor detects motion
 - Waits until ALL sensors are clear before starting the countdown
 - Uses `mode: restart` so new motion resets the timer
+
+### water_schedule.yaml
+Open a water valve on a schedule for a fixed duration, then close it. Built for a Sonoff smart water valve exposed as a `switch` via zigbee2mqtt, but works with any switch/valve entity.
+
+**Inputs:**
+- Water Valve - the switch/valve entity to control
+- Start Time - time of day to start watering
+- Watering Days - weekdays to run (multi-select)
+- Watering Duration - how long to keep the valve open
+- Skip Condition (optional) - skip watering when true (rain sensor, forecast, soil moisture)
+- Enable Toggle (optional) - `input_boolean` that must be on for the schedule to run
+
+**Behavior:**
+- Triggers at the start time, checks weekday + enable toggle + skip condition, then opens the valve, waits the duration, and closes it
+- Uses `mode: restart`; if HA restarts mid-watering the run is cancelled and the valve stays open (use a hardware auto-off timer or a separate safety automation if needed)

--- a/iot/homeassistant/blueprints/README.md
+++ b/iot/homeassistant/blueprints/README.md
@@ -42,3 +42,17 @@ Render each visible floor of the house (basement, first floor, attic) as a colou
 Turn on a light or switch when motion is detected.
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fswibrow%2Fhome-ops%2Fmain%2Fiot%2Fhomeassistant%2Fblueprints%2Fmotion_activated_light.yaml)
+
+## Water
+
+### Water Schedule (Sonoff Smart Water Valve)
+
+Open a water valve on a schedule for a fixed duration, then close it. Built for a
+Sonoff smart water valve exposed as a `switch` via zigbee2mqtt.
+
+- **Start time / days:** Runs at a configured time on the selected weekdays
+- **Duration:** Keeps the valve open for a set duration, then closes it
+- **Skip condition (optional):** Skip watering when e.g. a rain sensor is on or rain is forecast
+- **Enable toggle (optional):** Pause the schedule with an `input_boolean` instead of deleting it
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fswibrow%2Fhome-ops%2Fmain%2Fiot%2Fhomeassistant%2Fblueprints%2Fwater_schedule.yaml)

--- a/iot/homeassistant/blueprints/README.md
+++ b/iot/homeassistant/blueprints/README.md
@@ -1,5 +1,10 @@
 # Home Assistant Blueprints
 
+Home Assistant instance: <https://ha.wibrow.dev>
+
+To import a blueprint, click its **Import Blueprint** badge below (opens the
+import dialog in your Home Assistant instance).
+
 ## Aqara H2 Switches
 
 ### Single Rocker (WS-K07E)

--- a/iot/homeassistant/blueprints/water_schedule.yaml
+++ b/iot/homeassistant/blueprints/water_schedule.yaml
@@ -1,0 +1,130 @@
+blueprint:
+  name: Water Schedule (Sonoff Smart Water Valve)
+  source_url: https://github.com/swibrow/home-ops/blob/main/iot/homeassistant/blueprints/water_schedule.yaml
+  description: |
+    Open a water valve on a schedule for a fixed duration, then close it again.
+
+    Designed for a Sonoff smart water valve exposed as a `switch` entity via
+    zigbee2mqtt, but works with any switch/valve that can be turned on and off.
+
+    **Features:**
+    - Runs at a configured start time on selected days of the week
+    - Keeps the valve open for a configurable duration, then closes it
+    - Optional skip condition (e.g. rain sensor on, weather is rainy, soil already wet)
+    - Optional enable toggle (`input_boolean`) to pause the schedule without deleting it
+    - Re-triggering during a run restarts the timer (mode: restart)
+
+    Create one automation per watering slot. For multiple start times per day,
+    create the blueprint multiple times with different start times.
+
+    **Note:** If Home Assistant restarts mid-watering the run is cancelled and
+    the valve stays open. Set a hardware auto-off timer on the valve, or add a
+    separate "close valve" safety automation, if that matters for your setup.
+  domain: automation
+  author: Home Assistant
+  input:
+    valve_entity:
+      name: Water Valve
+      description: The switch/valve entity to control (Sonoff smart water valve via zigbee2mqtt)
+      selector:
+        entity:
+          filter:
+            - domain: switch
+            - domain: valve
+    start_time:
+      name: Start Time
+      description: Time of day to start watering
+      default: "06:00:00"
+      selector:
+        time: {}
+    watering_days:
+      name: Watering Days
+      description: Days of the week on which to water
+      default:
+        - mon
+        - tue
+        - wed
+        - thu
+        - fri
+        - sat
+        - sun
+      selector:
+        select:
+          multiple: true
+          mode: list
+          options:
+            - label: Monday
+              value: mon
+            - label: Tuesday
+              value: tue
+            - label: Wednesday
+              value: wed
+            - label: Thursday
+              value: thu
+            - label: Friday
+              value: fri
+            - label: Saturday
+              value: sat
+            - label: Sunday
+              value: sun
+    watering_duration:
+      name: Watering Duration
+      description: How long to keep the valve open
+      default:
+        hours: 0
+        minutes: 15
+        seconds: 0
+      selector:
+        duration: {}
+    skip_condition:
+      name: Skip Condition (optional)
+      description: >-
+        If this condition is true at the start time, watering is skipped.
+        Useful for rain sensors, weather forecasts, or soil moisture checks.
+      default: []
+      selector:
+        condition: {}
+    enable_entity:
+      name: Enable Toggle (optional)
+      description: >-
+        An input_boolean that must be on for the schedule to run. Leave empty
+        to always run. Lets you pause watering without deleting the automation.
+      default: []
+      selector:
+        entity:
+          filter:
+            - domain: input_boolean
+
+mode: restart
+max_exceeded: silent
+
+triggers:
+  - trigger: time
+    at: !input start_time
+
+variables:
+  enable_entity: !input enable_entity
+  watering_days: !input watering_days
+
+conditions:
+  - alias: "Today is a watering day"
+    condition: template
+    value_template: "{{ now().strftime('%a') | lower in watering_days }}"
+  - alias: "Schedule is enabled"
+    condition: template
+    value_template: "{{ enable_entity | length == 0 or is_state(enable_entity, 'on') }}"
+  - alias: "Skip condition is not met"
+    condition: not
+    conditions: !input skip_condition
+
+actions:
+  - alias: "Open the water valve"
+    action: homeassistant.turn_on
+    target:
+      entity_id: !input valve_entity
+  - alias: "Keep the valve open for the watering duration"
+    delay: !input watering_duration
+  - alias: "Close the water valve"
+    action: homeassistant.turn_off
+    target:
+      entity_id: !input valve_entity


### PR DESCRIPTION
Schedule a Sonoff smart water valve (z2m switch entity) to open at a set
time on selected weekdays for a fixed duration, then close. Supports an
optional skip condition (rain sensor/forecast) and an optional enable
toggle to pause without deleting the automation.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FxoNzfU8GPkDp7MtEhcp5p