### PR TITLE
feat(garrison): ArgoCD-managed deploy of the garrison hosted-mode stack

### DIFF
--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/Chart.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: garrison
+description: Garrison hosted mode — the keep control plane and its raid sandboxes
+type: application
+version: 0.1.0
+appVersion: "0.0.0"

--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/externalsecrets.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/externalsecrets.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.secrets.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garrison-keep-auth
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.secrets.externalSecrets.store }}
+  target:
+    name: {{ .Values.secrets.keepAuth }}
+    creationPolicy: Owner
+  data:
+    - secretKey: KEEP_API_TOKEN
+      remoteRef:
+        key: {{ .Values.secrets.externalSecrets.basePath }}/KEEP_API_TOKEN
+    - secretKey: KEEP_RUNNER_TOKEN
+      remoteRef:
+        key: {{ .Values.secrets.externalSecrets.basePath }}/KEEP_RUNNER_TOKEN
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garrison-runner-env
+  namespace: {{ .Values.runner.namespace }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.secrets.externalSecrets.store }}
+  target:
+    name: {{ .Values.secrets.runnerEnv }}
+    creationPolicy: Owner
+  data:
+    - secretKey: CLAUDE_CODE_OAUTH_TOKEN
+      remoteRef:
+        key: {{ .Values.secrets.externalSecrets.basePath }}/CLAUDE_CODE_OAUTH_TOKEN
+{{- if .Values.secrets.externalSecrets.githubApp }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garrison-github-app
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.secrets.externalSecrets.store }}
+  target:
+    name: garrison-github-app
+    creationPolicy: Owner
+  data:
+    - secretKey: GITHUB_APP_ID
+      remoteRef:
+        key: {{ .Values.secrets.externalSecrets.basePath }}/github-app/GITHUB_APP_ID
+    - secretKey: GITHUB_APP_PRIVATE_KEY
+      remoteRef:
+        key: {{ .Values.secrets.externalSecrets.basePath }}/github-app/GITHUB_APP_PRIVATE_KEY
+{{- end }}
+{{- end }}

--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/herald-deployment.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/herald-deployment.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.herald.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garrison-herald
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: garrison-herald
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: garrison-herald
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: garrison-herald
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: herald
+          image: {{ .Values.herald.image | default .Values.keep.image }}
+          imagePullPolicy: {{ .Values.keep.imagePullPolicy }}
+          command: ["node", "packages/herald/bin/herald.js"]
+          env:
+            - name: HERALD_KEEP_URL
+              value: http://garrison-keep.{{ .Release.Namespace }}.svc:{{ .Values.keep.port }}
+            - name: HERALD_ALLOWED_CHAT_IDS
+              value: {{ .Values.herald.allowedChatIds | quote }}
+            - name: HERALD_DATA_DIR
+              value: /data
+            - name: HERALD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.herald.secret }}
+                  key: HERALD_BOT_TOKEN
+            {{- if and .Values.secrets.authEnabled .Values.secrets.apiAuthEnabled }}
+            - name: HERALD_KEEP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.keepAuth }}
+                  key: KEEP_API_TOKEN
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: data
+          emptyDir: {}
+{{- if .Values.secrets.externalSecrets.enabled }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garrison-herald
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.secrets.externalSecrets.store }}
+  target:
+    name: {{ .Values.herald.secret }}
+    creationPolicy: Owner
+  data:
+    - secretKey: HERALD_BOT_TOKEN
+      remoteRef:
+        key: {{ .Values.secrets.externalSecrets.basePath }}/HERALD_BOT_TOKEN
+{{- end }}
+{{- end }}

--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/keep-deployment.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/keep-deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garrison-keep
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: garrison-keep
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: garrison-keep
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: garrison-keep
+    spec:
+      serviceAccountName: garrison-keep
+      {{- with .Values.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: keep
+          image: {{ .Values.keep.image }}
+          imagePullPolicy: {{ .Values.keep.imagePullPolicy }}
+          # GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY when the App is configured.
+          envFrom:
+            - secretRef:
+                name: garrison-github-app
+                optional: true
+          ports:
+            - containerPort: {{ .Values.keep.port }}
+              name: http
+          env:
+            - name: KEEP_PORT
+              value: {{ .Values.keep.port | quote }}
+            - name: KEEP_HARNESS
+              value: {{ .Values.harness }}
+            - name: KEEP_LAUNCHER
+              value: {{ .Values.launcher }}
+            - name: KEEP_FILE_ISSUES_ON_FAILURE
+              value: {{ .Values.fileIssuesOnFailure | quote }}
+            - name: KEEP_RUNNER_IMAGE
+              value: {{ .Values.runner.image }}
+            - name: KEEP_RUNS_NAMESPACE
+              value: {{ .Values.runner.namespace }}
+            - name: KEEP_RUNNER_ENV_SECRET
+              value: {{ .Values.secrets.runnerEnv }}
+            {{- with .Values.imagePullSecret }}
+            - name: KEEP_RUNNER_PULL_SECRET
+              value: {{ . }}
+            {{- end }}
+            - name: KEEP_PUBLIC_URL
+              value: {{ .Values.keep.publicUrl | default (printf "http://garrison-keep.%s.svc:%d" .Release.Namespace (int .Values.keep.port)) }}
+            {{- if and .Values.secrets.authEnabled .Values.secrets.apiAuthEnabled }}
+            - name: KEEP_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.keepAuth }}
+                  key: KEEP_API_TOKEN
+            {{- end }}
+            {{- if .Values.secrets.authEnabled }}
+            - name: KEEP_RUNNER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.keepAuth }}
+                  key: KEEP_RUNNER_TOKEN
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.keep.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: garrison-keep-data

--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/keep-httproute.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/keep-httproute.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garrison-keep
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: garrison-keep
+spec:
+  hostnames:
+    - {{ required "httpRoute.hostname is required when httpRoute.enabled" .Values.httpRoute.hostname }}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ required "httpRoute.gateway.name is required when httpRoute.enabled" .Values.httpRoute.gateway.name }}
+      {{- with .Values.httpRoute.gateway.namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .Values.httpRoute.gateway.sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+  rules:
+    - backendRefs:
+        - name: garrison-keep
+          port: {{ .Values.keep.port }}
+{{- end }}

--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/keep-pvc.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/keep-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: garrison-keep-data
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes: ["ReadWriteOnce"]
+  {{- with .Values.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}

--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/keep-rbac.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/keep-rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: garrison-keep
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: garrison-keep-sandboxes
+  namespace: {{ .Values.runner.namespace }}
+rules:
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["create", "get", "list", "watch", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: garrison-keep-sandboxes
+  namespace: {{ .Values.runner.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: garrison-keep-sandboxes
+subjects:
+  - kind: ServiceAccount
+    name: garrison-keep
+    namespace: {{ .Release.Namespace }}

--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/keep-service.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/keep-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: garrison-keep
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: garrison-keep
+spec:
+  selector:
+    app.kubernetes.io/name: garrison-keep
+  ports:
+    - name: http
+      port: {{ .Values.keep.port }}
+      targetPort: http

--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/runs-namespace.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/runs-namespace.yaml
@@ -1,0 +1,8 @@
+{{- if ne .Values.runner.namespace .Release.Namespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.runner.namespace }}
+  labels:
+    app.kubernetes.io/part-of: garrison
+{{- end }}

--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/runs-networkpolicy.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/templates/runs-networkpolicy.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.networkPolicy.enabled }}
+# Runner sandboxes may reach DNS, the keep, and external 443 (model API,
+# git hosting, package registries) — nothing else cluster-internal.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: garrison-runner-egress
+  namespace: {{ .Values.runner.namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: garrison-runner
+  policyTypes: ["Egress"]
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: garrison-keep
+      ports:
+        - protocol: TCP
+          port: {{ .Values.keep.port }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+{{- end }}

--- a/kubernetes/apps/pitower/garrison/garrison/chart/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/chart/garrison/values.yaml
@@ -1,0 +1,75 @@
+keep:
+  image: garrison-keep:dev
+  imagePullPolicy: IfNotPresent
+  port: 8787
+  # URL runners dial; defaults to the in-cluster service DNS name.
+  publicUrl: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+herald:
+  enabled: false
+  # Defaults to the keep image (it carries every package).
+  image: ""
+  allowedChatIds: ""
+  secret: garrison-herald
+
+# dockerconfigjson secret for pulling private images (keep, herald, and
+# runner sandbox pods). Create it out-of-band in the release namespace, and
+# in runner.namespace too when that differs. Empty disables the reference.
+imagePullSecret: ""
+
+runner:
+  image: garrison-runner:dev
+  namespace: garrison-runs
+  # Optional RuntimeClass for kernel isolation (gVisor/Kata) where available.
+  runtimeClassName: ""
+
+# claude for real raids; fake runs the whole pipeline scripted at zero tokens.
+harness: claude
+# sandbox (agent-sandbox CRs) | process (keep-local child processes) | none
+launcher: sandbox
+# Opt-in: auto-file a GitHub issue on a raid's repo when it fails (needs the
+# GitHub App configured — secrets.externalSecrets.githubApp or garrison-github-app).
+fileIssuesOnFailure: false
+
+persistence:
+  size: 5Gi
+  storageClassName: ""
+
+# Secrets are referenced, never templated with real values. Either create
+# them out-of-band (kubectl create secret ...) or enable externalSecrets to
+# sync them from an external-secrets ClusterSecretStore (Infisical):
+#   <basePath>/KEEP_API_TOKEN, <basePath>/KEEP_RUNNER_TOKEN → garrison-keep-auth
+#   <basePath>/CLAUDE_CODE_OAUTH_TOKEN                      → garrison-runner-env
+#   <basePath>/github-app/GITHUB_APP_ID + _PRIVATE_KEY      → garrison-github-app
+secrets:
+  runnerEnv: garrison-runner-env
+  keepAuth: garrison-keep-auth
+  # Set false in dev to run tokenless (kind, fake harness).
+  authEnabled: true
+  # Set false to open /api/v1 (wartable, CLI) while runners on /internal
+  # stay token-gated — for deployments only reachable over VPN/LAN.
+  apiAuthEnabled: true
+  externalSecrets:
+    enabled: false
+    store: infisical
+    basePath: /garrison
+    githubApp: false
+
+networkPolicy:
+  enabled: true
+
+# Gateway API route exposing the keep (wartable SPA + /api) at a hostname.
+httpRoute:
+  enabled: false
+  hostname: ""
+  gateway:
+    name: ""
+    namespace: ""
+    sectionName: https

--- a/kubernetes/apps/pitower/garrison/garrison/kustomization.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmGlobals:
+  chartHome: chart
+
+helmCharts:
+  - name: garrison
+    valuesFile: values.yaml

--- a/kubernetes/apps/pitower/garrison/garrison/kustomization.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: garrison
+
 helmGlobals:
   chartHome: chart
 

--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -1,0 +1,50 @@
+# Home cluster (admin@pitower): everything in the garrison namespace,
+# secrets synced from Infisical via the external-secrets ClusterSecretStore.
+# Pin images by git sha (garrison's CI tags every build and patches this
+# file on every push to main): spegel resolves mutable tags like :latest
+# from peer caches, serving stale images.
+keep:
+  image: ghcr.io/swibrow/garrison-keep:d05a3495ccd5c67f980b231fbb3687e9fa3de005
+  imagePullPolicy: IfNotPresent
+
+# ghcr packages stay private (the repo is private); created out-of-band:
+#   kubectl -n garrison create secret docker-registry ghcr-pull-secret \
+#     --docker-server=ghcr.io --docker-username=swibrow --docker-password=<read:packages token>
+imagePullSecret: ghcr-pull-secret
+
+runner:
+  image: ghcr.io/swibrow/garrison-runner:d05a3495ccd5c67f980b231fbb3687e9fa3de005
+  namespace: garrison
+
+harness: claude
+launcher: sandbox
+
+herald:
+  enabled: true
+  allowedChatIds: "1053711635"
+
+secrets:
+  authEnabled: true
+  # wartable is VPN-only (envoy-internal); /internal stays token-gated.
+  apiAuthEnabled: false
+  externalSecrets:
+    enabled: true
+    store: infisical
+    basePath: /garrison
+    # garrison-github-app was created manually (kubectl) — flip on if the
+    # creds move into Infisical at /garrison/github-app.
+    githubApp: false
+
+persistence:
+  size: 5Gi
+
+networkPolicy:
+  enabled: true
+
+httpRoute:
+  enabled: true
+  hostname: garrison.wibrow.dev
+  gateway:
+    name: envoy-internal
+    namespace: networking
+    sectionName: https


### PR DESCRIPTION
## Summary
- Adds `kubernetes/apps/pitower/garrison/garrison/`, picked up automatically by the existing `pitower` ApplicationSet (`kubernetes/argocd/clusters/pitower.yaml`) — no ArgoCD-side config change needed.
- Vendors garrison's Helm chart (`chart/garrison/`, mirrored from `swibrow/garrison`'s `deploy/charts/garrison`) plus the pitower values overlay (`values.yaml`, seeded verbatim from garrison's now-removed `deploy/pitower/values.yaml`).
- Going forward, garrison's CI (`deploy-pitower` job in its `ci.yaml`) will keep `chart/garrison/` in sync and patch `keep.image`/`runner.image` in `values.yaml` to the new sha on every push to `main`, committing straight to this repo's `main`. This PR is the one-time manual bootstrap; everything after this merges automatically.

## Why two files instead of one
`values.yaml` here layers on top of the chart's own default `values.yaml` (inside `chart/garrison/`) via kustomize's local-chart `helmCharts` + `helmGlobals.chartHome` inflation — the same merge behavior as today's `helm upgrade -f deploy/pitower/values.yaml`. This preserves defaults (resource requests/limits, `keep.port`, default secret names) that the pitower overlay never had to repeat.

## Verified
- `kustomize build --enable-helm kubernetes/apps/pitower/garrison/garrison` renders successfully.
- Diffed the rendered `garrison-keep` Deployment against what's actually live on pitower today (`kubectl -n garrison get deploy garrison-keep -o yaml`) — identical spec modulo server-defaulted fields (`protocol: TCP`, `terminationMessagePath`, etc).

## Auth for the write-back
garrison's `deploy-pitower` CI job authenticates as the `garrison-keep` GitHub App (the same App keep uses at runtime to ship raid PRs) rather than a static PAT — it mints a short-lived installation token scoped to this repo via `actions/create-github-app-token`. The App needs to be installed with access to `home-ops` for that to work.

## Test plan
- [ ] Merge this PR
- [ ] Confirm ArgoCD creates `pitower-garrison-garrison` and syncs cleanly against the existing manually-`helm`-installed resources (server-side apply should adopt them; if ArgoCD instead reports ownership conflicts, `helm uninstall garrison -n garrison` first and let ArgoCD do a fresh install)
- [ ] `kubectl -n garrison get all` before/after to confirm nothing was pruned unexpectedly
- [ ] Install/configure the `garrison-keep` GitHub App with access to `swibrow/home-ops` (Settings → Applications → Garrison Keep → Configure)
- [ ] Set `GARRISON_KEEP_APP_ID` and `GARRISON_KEEP_APP_PRIVATE_KEY` secrets on `swibrow/garrison` so the `deploy-pitower` job can mint tokens