### PR TITLE
chore(garrison): allow chat 5540433154 in herald

### DIFF
--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -17,7 +17,7 @@ harness: claude
 launcher: sandbox
 herald:
   enabled: true
-  allowedChatIds: "1053711635"
+  allowedChatIds: "1053711635,5540433154"
 secrets:
   authEnabled: true
   # wartable is VPN-only (envoy-internal); /internal stays token-gated.


### PR DESCRIPTION
## Summary
- Adds Telegram chat id `5540433154` to garrison's herald allowlist alongside the existing chat (sam's), so it can use the bot on pitower.

## Test plan
- [ ] ArgoCD syncs the change to the `garrison` release on pitower
- [ ] Confirm herald responds to the new chat id (previously-rejected chat ids are logged, so it can be double-checked in pod logs if it doesn't work)