### PR TITLE
fix(garrison): correct herald chat id sign for group chat

### DIFF
--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -17,7 +17,7 @@ harness: claude
 launcher: sandbox
 herald:
   enabled: true
-  allowedChatIds: "1053711635,5540433154"
+  allowedChatIds: "1053711635,-5540433154"
 secrets:
   authEnabled: true
   # wartable is VPN-only (envoy-internal); /internal stays token-gated.


### PR DESCRIPTION
## Summary
- Telegram group chat ids are negative. #1345 added `5540433154` but the bot's logs show the real id is `-5540433154`, so herald was still rejecting it after that PR merged.
- Fixes `allowedChatIds` to `"1053711635,-5540433154"`.

## Test plan
- [ ] ArgoCD syncs the change to pitower
- [ ] Confirm herald no longer logs `ignoring chat -5540433154`