### PR TITLE
feat(homeassistant): add SLZB-06 zigbee radio crash monitor

### DIFF
--- a/iot/homeassistant/packages/zigbee_radio_monitor.yaml
+++ b/iot/homeassistant/packages/zigbee_radio_monitor.yaml
@@ -1,0 +1,42 @@
+automation:
+  - alias: "Zigbee Radio - Connection Lost"
+    description: >-
+      The SLZB-06's zigbee radio occasionally hangs, dropping the
+      Zigbee2MQTT bridge connection until it's restarted. Auto-trigger a
+      zigbee-only restart (leaves ethernet/core untouched) after a sustained
+      outage and notify either way.
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.zigbee2mqtt_bridge_connection_state
+        to: "off"
+        for:
+          minutes: 5
+    actions:
+      - action: button.press
+        target:
+          entity_id: button.slzb_06_zigbee_restart
+      - action: notify.mobile_app_sammi_iphone
+        data:
+          title: "Zigbee radio restarted"
+          message: >-
+            Zigbee2MQTT lost connection to the SLZB-06 for 5+ minutes.
+            Triggered an automatic Zigbee-only restart.
+
+  - alias: "Zigbee Radio - Restart Did Not Help"
+    description: >-
+      Bridge still disconnected 15 minutes in, well past the automatic
+      restart above - it didn't recover on its own, so escalate.
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.zigbee2mqtt_bridge_connection_state
+        to: "off"
+        for:
+          minutes: 15
+    actions:
+      - action: notify.mobile_app_sammi_iphone
+        data:
+          title: "⚠️ Zigbee radio still down"
+          message: >-
+            SLZB-06 Zigbee radio has been disconnected for 15+ minutes and
+            the automatic restart didn't fix it. A full Core restart may be
+            needed.


### PR DESCRIPTION
## Summary
- The SLZB-06's zigbee radio occasionally hangs, requiring a manual restart every couple weeks. History shows `binary_sensor.zigbee2mqtt_bridge_connection_state` was down for 4+ days (2026-07-03 → 2026-07-07) before this was noticed.
- New package `iot/homeassistant/packages/zigbee_radio_monitor.yaml` adds two automations:
  - **Connection Lost**: after 5 minutes of bridge disconnection, presses `button.slzb_06_zigbee_restart` (radio-only soft reset, doesn't touch Ethernet/core) and notifies via `notify.mobile_app_sammi_iphone`.
  - **Restart Did Not Help**: if still disconnected after 15 minutes, sends an escalated notification suggesting a full Core restart.

## Test plan
- [ ] Confirm the Git Pull add-on syncs the new package into the running HA config
- [ ] Reload automations (or wait for HA restart) and verify both automations appear under Settings > Automations
- [ ] Simulate/observe a real bridge disconnect and confirm the restart button press + notification fire as expected