### PR TITLE
chore(garrison): deploy v0.1.0

### DIFF
--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -1,17 +1,17 @@
 # Home cluster (admin@pitower): everything in the garrison namespace,
 # secrets synced from Infisical via the external-secrets ClusterSecretStore.
-# Pin images by git sha (garrison's CI tags every build and patches this
-# file on every push to main): spegel resolves mutable tags like :latest
-# from peer caches, serving stale images.
+# Pin images by release version (garrison's CI patches this file when it
+# cuts a release): spegel resolves mutable tags like :latest from peer
+# caches, serving stale images.
 keep:
-  image: ghcr.io/swibrow/garrison-keep:6aea7adbb13f0b1de43b569678dbd0e521086fb6
+  image: ghcr.io/swibrow/garrison-keep:v0.1.0
   imagePullPolicy: IfNotPresent
 # ghcr packages stay private (the repo is private); created out-of-band:
 #   kubectl -n garrison create secret docker-registry ghcr-pull-secret \
 #     --docker-server=ghcr.io --docker-username=swibrow --docker-password=<read:packages token>
 imagePullSecret: ghcr-pull-secret
 runner:
-  image: ghcr.io/swibrow/garrison-runner:6aea7adbb13f0b1de43b569678dbd0e521086fb6
+  image: ghcr.io/swibrow/garrison-runner:v0.1.0
   namespace: garrison
 harness: claude
 launcher: sandbox


### PR DESCRIPTION
Deploy of garrison v0.1.0 (swibrow/garrison@a3f8d17621f845903fab70bd3b5688cb5eccabc7). Completes the release run whose deploy job was skipped when the release job failed post-publish; images were version-tagged manually.