### PR TITLE
feat(garrison): CNPG postgres cluster + db-secret sync for HA mode

### DIFF
--- a/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
@@ -314,3 +314,24 @@ spec:
     storageClass: openebs-hostpath
   monitoring:
     enablePodMonitor: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: garrison
+  namespace: cloudnative-pg
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:18
+  bootstrap:
+    initdb:
+      # One database, two schemas: the keep owns `keep`, the herald owns
+      # `herald` — the garrison services create them at boot.
+      database: garrison
+      owner: garrison
+  storage:
+    size: 2Gi
+    storageClass: openebs-hostpath
+  monitoring:
+    enablePodMonitor: true

--- a/kubernetes/apps/pitower/garrison/garrison/kustomization.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/kustomization.yaml
@@ -1,6 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: garrison
+components:
+  - ../../../../components/cnpg-db
+configMapGenerator:
+  - name: cnpg-db-config
+    literals:
+      - APP_NAME=garrison
+      - SECRET_NAME=garrison-db-secret
+      - CNPG_SECRET_KEY=garrison-app
 helmCharts:
   - name: garrison
     repo: oci://ghcr.io/swibrow/charts


### PR DESCRIPTION
## Summary

Provisions the shared Postgres for garrison's HA work (swibrow/garrison#111) following the house patterns:

- **`garrison` CNPG cluster** in `cloudnative-pg` (postgresql:**18**, 2 instances, openebs-hostpath, pod monitor — same shape as the sibling clusters, picks up the existing affinity patch). One database `garrison`; the keep and herald create their own schemas (`keep`, `herald`) at boot.
- **`cnpg-db` component** wired into the garrison app kustomization, so the CNPG-generated app credentials sync into the `garrison` namespace as `garrison-db-secret` (with the ready-made `DB_URL` key) — no Infisical-pinned password needed.

## Rollout sequencing

This PR is **provisioning only** — nothing changes for the running services:

1. Merge this: the cluster comes up, `garrison-db-secret` materializes in ns `garrison`.
2. swibrow/garrison#111 merges and releases; CI bumps the chart version here as usual.
3. Cutover (few minutes downtime, runbook in garrison `docs/postgres.md`): scale keep+herald to 0, run the idempotent sqlite→postgres Job, then set in `values.yaml`:
   ```yaml
   database:
     enabled: true
     secret: garrison-db-secret
     secretKey: DB_URL
   ```
4. Keep the old PVCs until the new world has proven itself.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/pitower/cloudnative-pg/cluster/` renders the garrison Cluster with the affinity patch
- [x] `kubectl kustomize --enable-helm kubernetes/apps/pitower/garrison/garrison/` renders the `garrison-db` ExternalSecret → `garrison-db-secret` (key `garrison-app` via `cnpg-secrets`)
- [ ] After merge: cluster `garrison` healthy (2 instances), `garrison-db-secret` Synced in ns garrison