### PR TITLE
feat(garrison): enable postgres + HA on pitower

### DIFF
--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -3,6 +3,15 @@
 # Pin images by release version (garrison's CI patches this file when it
 # cuts a release): spegel resolves mutable tags like :latest from peer
 # caches, serving stale images.
+#
+# database.enabled flips keep/herald to Postgres + HA (2 replicas each);
+# garrison-db-secret is the CNPG-generated app credential (see
+# cloudnative-pg/cluster/cluster.yaml + the cnpg-db kustomize component).
+# Cut over per garrison's docs/postgres.md runbook.
+database:
+  enabled: true
+  secret: garrison-db-secret
+  secretKey: DB_URL
 keep:
   image: ghcr.io/swibrow/garrison-keep:v0.13.0
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- Flip `database.enabled: true` for the pitower garrison deployment, pointing at the CNPG-provisioned `garrison-db-secret` (`DB_URL` key) from #1438.
- Brings `keep` and `herald` up to 2 replicas each in HA mode (leader election over Postgres advisory locks).

## Context
CNPG `garrison` cluster is healthy in-cluster. SQLite → Postgres data migration has already run and been verified against the live pods (no drift):

- `keep.documents`: 69/69
- `keep.events`: 1550/1550 (relay cursor seeded at 1550, no Telegram replay)
- `herald.bindings` / `raid_chats` / `subscriptions`: 0/0/0

Runbook: `docs/postgres.md` in swibrow/garrison.

## Test plan
- [ ] ArgoCD syncs this to the `garrison` app in the pitower cluster
- [ ] `kubectl -n garrison get pods` — all Ready, 2x keep + 2x herald
- [ ] One keep pod's `/healthz` reports `{"role":"leader"}`, the other `{"role":"standby"}`
- [ ] wartable lists the pre-existing raids/issues
- [ ] Telegram `/status` answers

Claude-Session: https://claude.ai/code/session_01QnyE18fV3xn5gD6m3HYpz9