### PR TITLE
feat(ai): deploy memini alongside agentmemory

### DIFF
--- a/kubernetes/apps/pitower/ai/litellm/config.yaml
+++ b/kubernetes/apps/pitower/ai/litellm/config.yaml
@@ -17,6 +17,12 @@ model_list:
       model: openrouter/anthropic/claude-haiku-4.5
       api_key: os.environ/OPENROUTER_API_KEY
 
+  # --- Embeddings (memini) ---
+  - model_name: memini-embed
+    litellm_params:
+      model: openai/text-embedding-3-small
+      api_key: os.environ/OPENAI_API_KEY
+
   # --- OpenRouter (named aliases, auto-curated from the live catalog) ---
   # Newest ~5 chat models per major provider so they show in the dropdown.
   # Any other OpenRouter model is still reachable by full id via the catch-all.

--- a/kubernetes/apps/pitower/ai/litellm/externalsecret.yaml
+++ b/kubernetes/apps/pitower/ai/litellm/externalsecret.yaml
@@ -27,3 +27,7 @@ spec:
     - secretKey: OPENROUTER_API_KEY
       remoteRef:
         key: /ai/litellm/OPENROUTER_API_KEY
+    # text-embedding-3-small — serves memini's embeddings model.
+    - secretKey: OPENAI_API_KEY
+      remoteRef:
+        key: /ai/litellm/OPENAI_API_KEY

--- a/kubernetes/apps/pitower/ai/memini/externalsecret.yaml
+++ b/kubernetes/apps/pitower/ai/memini/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name memini
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: *name
+    creationPolicy: Owner
+  data:
+    # Bearer token for memini's own /v1, /mcp, and admin UI.
+    - secretKey: MEMINI_API_KEY
+      remoteRef:
+        key: /ai/memini/MEMINI_API_KEY
+    # litellm master key, reused as the bearer token for the embeddings and
+    # chat (consolidation/dedup/rerank) endpoints proxied through litellm.
+    - secretKey: MEMINI_LITELLM_API_KEY
+      remoteRef:
+        key: /ai/litellm/LITELLM_MASTER_KEY

--- a/kubernetes/apps/pitower/ai/memini/kustomization.yaml
+++ b/kubernetes/apps/pitower/ai/memini/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+resources:
+  - externalsecret.yaml
+components:
+  - ../../../../components/cnpg-db
+configMapGenerator:
+  - name: cnpg-db-config
+    options:
+      disableNameSuffixHash: true
+    literals:
+      - APP_NAME=memini
+      - SECRET_NAME=memini-db-secret
+      - CNPG_SECRET_KEY=memini-app
+helmCharts:
+  - name: memini
+    repo: oci://registry.erwanleboucher.dev/eleboucher/charts
+    version: v0.5.12
+    releaseName: memini
+    namespace: ai
+    valuesFile: values.yaml

--- a/kubernetes/apps/pitower/ai/memini/values.yaml
+++ b/kubernetes/apps/pitower/ai/memini/values.yaml
@@ -1,0 +1,75 @@
+controllers:
+  main:
+    type: deployment
+    replicas: 1
+    annotations:
+      reloader.stakater.com/auto: "true"
+    containers:
+      main:
+        env:
+          MEMINI_BACKEND: postgres
+          MEMINI_DEFAULT_NAMESPACE: default
+          MEMINI_POSTGRES_DSN:
+            valueFrom:
+              secretKeyRef:
+                name: memini-db-secret
+                key: DB_URL
+          MEMINI_EMBED_BASE_URL: http://litellm:4000/v1
+          MEMINI_EMBED_MODEL: memini-embed
+          MEMINI_EMBED_DIMS: "1536"
+          MEMINI_EMBED_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: memini
+                key: MEMINI_LITELLM_API_KEY
+          MEMINI_REEMBED_ON_MODEL_CHANGE: "true"
+          MEMINI_LLM_BASE_URL: http://litellm:4000/v1
+          MEMINI_LLM_MODEL: claude-haiku
+          MEMINI_LLM_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: memini
+                key: MEMINI_LITELLM_API_KEY
+          # Reuses the chat LLM above for recall reranking — no dedicated
+          # cross-encoder reranker deployed.
+          MEMINI_RERANK: llm
+          MEMINI_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: memini
+                key: MEMINI_API_KEY
+          TZ: Europe/Zurich
+        resources:
+          requests:
+            cpu: 15m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
+
+persistence:
+  data:
+    enabled: false
+
+route:
+  main:
+    enabled: true
+    hostnames: ["memini-api.wibrow.dev"]
+    parentRefs:
+      - name: envoy-internal
+        namespace: networking
+        sectionName: https
+  ui:
+    enabled: true
+    hostnames: ["memini.wibrow.dev"]
+    parentRefs:
+      - name: envoy-internal
+        namespace: networking
+        sectionName: https
+
+serviceMonitor:
+  main:
+    enabled: true
+
+grafanaDashboards:
+  enabled: true
+  folder: ai

--- a/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
@@ -335,3 +335,30 @@ spec:
     storageClass: openebs-hostpath
   monitoring:
     enablePodMonitor: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: memini
+  namespace: cloudnative-pg
+spec:
+  instances: 2
+  # VectorChord-enabled Postgres build (not the stock CNPG image) — memini's
+  # postgres backend runs `CREATE EXTENSION IF NOT EXISTS vchord CASCADE`
+  # itself at startup and needs the extension binaries present.
+  imageName: ghcr.io/tensorchord/vchord-postgres:pg17-v0.5.1
+  enableSuperuserAccess: true
+  bootstrap:
+    initdb:
+      database: memini
+      owner: memini
+      # Runs as superuser against the new database during bootstrap, since
+      # the memini app user has no CREATE EXTENSION privilege on its own.
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS vchord CASCADE
+  storage:
+    size: 1Gi
+    storageClass: openebs-hostpath
+  monitoring:
+    enablePodMonitor: true


### PR DESCRIPTION
## Summary
- Deploys [eleboucher/memini](https://github.com/eleboucher/memini) as an `agentmemory` replacement candidate, adapted from joryirving's home-ops config (which assumes FluxCD + a local llmkube/DRA GPU inference stack neither of which exist in this cluster).
- New CNPG cluster `memini` on `ghcr.io/tensorchord/vchord-postgres:pg17-v0.5.1` (needed for the `vchord` extension memini's postgres backend requires; extension created via `postInitApplicationSQL` at bootstrap).
- litellm: adds `memini-embed` → `openai/text-embedding-3-small`, plus a new `OPENAI_API_KEY` provider secret. Reuses the existing `claude-haiku` model for consolidation/dedup/answering and LLM-based recall reranking (`MEMINI_RERANK=llm`) — no dedicated GPU/reranker infra.
- New app `kubernetes/apps/pitower/ai/memini/`, routed at `memini.wibrow.dev` (admin UI) and `memini-api.wibrow.dev` (REST + MCP) on `envoy-internal`.
- Runs **alongside** `agentmemory` for now; cutover (rewiring hermes, removing agentmemory) is a follow-up once validated.

## Manual steps before this deploys cleanly
- Add `/ai/litellm/OPENAI_API_KEY` to Infisical (OpenAI key with embeddings access).
- Add `/ai/memini/MEMINI_API_KEY` to Infisical (any strong random token — bearer auth for memini's API/UI).

## Test plan
- [x] `kustomize build --enable-helm` on `kubernetes/apps/pitower/ai/memini` renders cleanly
- [x] `kustomize build --enable-helm` on `kubernetes/apps/pitower/ai/litellm` renders cleanly with the new embeddings model + secret
- [x] `kustomize build` on `kubernetes/apps/pitower/cloudnative-pg/cluster` renders the new `memini` Cluster with the existing worker-05/06 affinity patch applied
- [x] Add the two Infisical secrets above, let ArgoCD sync, confirm the `memini` CNPG cluster comes up healthy and the `vchord` extension is created
- [ ] Confirm `memini` pod is healthy (`/healthz`, `/readyz`) and can recall/remember via MCP or REST
- [ ] Confirm `memini.wibrow.dev` and `memini-api.wibrow.dev` resolve and route correctly