### PR TITLE
fix(garrison): sync github-app secret from Infisical, incl. webhook secret

### DIFF
--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -35,9 +35,7 @@ secrets:
     enabled: true
     store: infisical
     basePath: /garrison
-    # garrison-github-app was created manually (kubectl) — flip on if the
-    # creds move into Infisical at /garrison/github-app.
-    githubApp: false
+    githubApp: true
 persistence:
   size: 5Gi
 networkPolicy:


### PR DESCRIPTION
## Summary
- keep logs show \`githubWebhookSecretConfigured: false\` — \`garrison-github-app\` was created manually and only carries \`GITHUB_APP_ID\`/\`GITHUB_APP_PRIVATE_KEY\`, so the webhook route accepts unsigned deliveries.
- \`/garrison/github-app\` in Infisical now has all three keys (incl. \`GITHUB_WEBHOOK_SECRET\`); flip \`secrets.externalSecrets.githubApp: true\` so ExternalSecrets manages \`garrison-github-app\` (creationPolicy: Owner adopts/replaces the manual one).

Related: swibrow/garrison#114 adds a way to route \`/webhooks/github\` through a separate, internet-reachable gateway, since \`garrison.wibrow.dev\` is currently bound to \`envoy-internal\` (VPN-only) — GitHub can't reach the webhook endpoint at all today regardless of the signing secret. Once that chart version ships, a follow-up here will set \`httpRoute.webhookExternal\` to a dedicated hostname (\`garrison-hooks.wibrow.dev\`) on \`envoy-external\`.

## Test plan
- [ ] After merge, confirm \`garrison-github-app\` ExternalSecret reports \`SecretSynced\`/\`Ready\` and has 3 keys (\`kubectl -n garrison describe secret garrison-github-app\`)
- [ ] Confirm keep's \`config loaded\` log shows \`githubWebhookSecretConfigured: true\` on next restart

https://claude.ai/code/session_01QnyE18fV3xn5gD6m3HYpz9