### PR TITLE
fix(cloudnative-pg): use ClusterImageCatalog for memini's vchord image

### DIFF
--- a/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
@@ -336,6 +336,20 @@ spec:
   monitoring:
     enablePodMonitor: true
 ---
+# CNPG's Cluster webhook parses spec.imageName's tag as a Postgres version
+# (e.g. "17.2") and rejects anything else, so tensorchord's "pg17-v0.5.1"
+# style tags can't be used directly there. A ClusterImageCatalog sidesteps
+# that: it maps the odd tag to an explicit major version, referenced from
+# the Cluster via imageCatalogRef instead of imageName.
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: vchord-postgres
+spec:
+  images:
+    - image: ghcr.io/tensorchord/vchord-postgres:pg17-v0.5.1
+      major: 17
+---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
@@ -347,7 +361,11 @@ spec:
   # VectorChord-enabled Postgres build (not the stock CNPG image) — memini's
   # postgres backend runs `CREATE EXTENSION IF NOT EXISTS vchord CASCADE`
   # itself at startup and needs the extension binaries present.
-  imageName: ghcr.io/tensorchord/vchord-postgres:pg17-v0.5.1
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: vchord-postgres
+    major: 17
   enableSuperuserAccess: true
   bootstrap:
     initdb:

--- a/kubernetes/apps/pitower/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/pitower/cloudnative-pg/cluster/kustomization.yaml
@@ -2,7 +2,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cloudnative-pg
+# No top-level `namespace:` — every Cluster in cluster.yaml already declares
+# its own `metadata.namespace: cloudnative-pg`, and the cluster-scoped
+# ClusterImageCatalog must NOT have one (the API server rejects it).
 resources:
   - cluster.yaml
 patches:


### PR DESCRIPTION
## Summary
Fixes a deploy-time failure from #1441: the CNPG admission webhook rejected `spec.imageName: ghcr.io/tensorchord/vchord-postgres:pg17-v0.5.1` with `invalid version tag`, because CNPG parses the image tag as a Postgres version and tensorchord's `pgNN-vX.Y.Z` tag scheme doesn't match that format (confirmed against CNPG's `validateImageName` — plain tags and digest-only refs are both rejected for this image).

- Adds a `ClusterImageCatalog` (`vchord-postgres`) mapping the image to an explicit `major: 17`, and switches the `memini` Cluster to `imageCatalogRef` instead of `imageName`.
- Dropped the cluster kustomization's top-level `namespace: cloudnative-pg` — every `Cluster` already self-declares its namespace inline, and the new `ClusterImageCatalog` is cluster-scoped, so the blanket namespace transform was getting it rejected by the API server (`must be empty` for cluster-scoped resources).

## Test plan
- [x] `kustomize build kubernetes/apps/pitower/cloudnative-pg/cluster` renders cleanly: 18 `Cluster` resources still carry `namespace: cloudnative-pg`, the `ClusterImageCatalog` carries none
- [ ] After merge, confirm the CNPG admission webhook accepts the `memini` Cluster and it comes up healthy with the `vchord` extension created