### PR TITLE
fix(cloudnative-pg): pin memini's postgresUID/GID to the image's 999

### DIFF
--- a/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
@@ -366,6 +366,11 @@ spec:
     kind: ClusterImageCatalog
     name: vchord-postgres
     major: 17
+  # tensorchord/vchord-postgres is Debian-based (postgres user is 999:999),
+  # not CNPG's own UBI-style images which default to 26:26 — without this,
+  # initdb runs as a UID the image doesn't have and fails immediately.
+  postgresUID: 999
+  postgresGID: 999
   enableSuperuserAccess: true
   bootstrap:
     initdb:


### PR DESCRIPTION
## Summary
Follow-up to #1443 — the `memini` cluster now passes the admission webhook, but `initdb` failed at bootstrap:

```
initdb: could not look up effective user ID 26: user does not exist
Error while bootstrapping data directory
```

CNPG defaults `postgresUID`/`postgresGID` to `26`/`26`, matching its own UBI-style operand images. I extracted `/etc/passwd` from `ghcr.io/tensorchord/vchord-postgres:pg17-v0.5.1`'s layers directly and confirmed it's Debian-based, where the `postgres` user is `999:999` — so the pod was running as a UID the image doesn't have.

Sets `spec.postgresUID: 999` / `spec.postgresGID: 999` on the `memini` Cluster only; every other cluster in the file keeps the CNPG default.

## Test plan
- [x] `kustomize build kubernetes/apps/pitower/cloudnative-pg/cluster` renders cleanly; only the `memini` Cluster carries `postgresUID`/`postgresGID: 999`
- [x] Confirmed `999:999` is the image's actual `postgres` UID/GID by extracting `/etc/passwd` from the image layers
- [ ] After merge, confirm `initdb` completes and the `memini` cluster reaches healthy