### PR TITLE
feat(garrison): expose the GitHub webhook path via envoy-external

### DIFF
--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -47,3 +47,13 @@ httpRoute:
     name: envoy-internal
     namespace: networking
     sectionName: https
+  # GitHub can't reach envoy-internal (VPN-only) to deliver App webhooks —
+  # route just POST /webhooks/github through envoy-external instead. Update
+  # the GitHub App's webhook URL to https://garrison-hooks.wibrow.dev/webhooks/github.
+  webhookExternal:
+    enabled: true
+    hostname: garrison-hooks.wibrow.dev
+    gateway:
+      name: envoy-external
+      namespace: networking
+      sectionName: https


### PR DESCRIPTION
## Summary
- `garrison.wibrow.dev` is bound to `envoy-internal` (VPN-only, private IP) — GitHub's servers can't reach `POST /webhooks/github` there at all, regardless of the signing secret fixed in #1442.
- garrison v0.14.0 (swibrow/garrison#114) adds `httpRoute.webhookExternal`: a second HTTPRoute scoped to only `/webhooks/github`, on its own hostname + gateway. Everything else (wartable, /api) stays on the internal route, untouched.
- Enables it here: `garrison-hooks.wibrow.dev` on `envoy-external`.

## Follow-up (manual, on github.com)
- [ ] Update the "Garrison Keep" GitHub App's webhook URL to `https://garrison-hooks.wibrow.dev/webhooks/github`

## Test plan
- [x] `helm template` against the chart (source-verified equivalent to the published v0.14.0) renders both HTTPRoutes correctly, webhook route scoped to `/webhooks/github` only on `envoy-external`
- [ ] After merge: `kubectl -n garrison get httproute garrison-keep-webhook`, confirm `Accepted`/`ResolvedRefs` conditions and DNS resolves `garrison-hooks.wibrow.dev` externally
- [ ] After GitHub App URL update: trigger a test delivery, confirm 200 in keep logs

https://claude.ai/code/session_01QnyE18fV3xn5gD6m3HYpz9