### PR TITLE
fix(cloudnative-pg): preload vchord for the memini cluster

### DIFF
--- a/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
@@ -372,6 +372,13 @@ spec:
   postgresUID: 999
   postgresGID: 999
   enableSuperuserAccess: true
+  postgresql:
+    # vchord is a background-worker extension, not a pure-SQL one — it must
+    # be loaded at postmaster start via shared_preload_libraries, or
+    # CREATE EXTENSION fails with "vchord must be loaded via
+    # shared_preload_libraries."
+    shared_preload_libraries:
+      - vchord
   bootstrap:
     initdb:
       database: memini


### PR DESCRIPTION
## Summary
Follow-up to #1445 — `initdb` now runs as the right UID, but bootstrap's `postInitApplicationSQL` fails:

```
ERROR: vchord must be loaded via shared_preload_libraries. (SQLSTATE XX000)
```

`vchord` is a background-worker extension (like `pg_stat_statements`), not a pure-SQL one — it has to be listed in `shared_preload_libraries` before the postmaster starts, not just `CREATE EXTENSION`'d. CNPG blocks setting `shared_preload_libraries` directly via `spec.postgresql.parameters` (it's operator-managed), so this uses the dedicated `spec.postgresql.shared_preload_libraries` field instead, which CNPG merges into its generated config before the first instance start — including during initdb bootstrap, so the `CREATE EXTENSION` in `postInitApplicationSQL` should now succeed on the same run.

## Test plan
- [x] `kustomize build kubernetes/apps/pitower/cloudnative-pg/cluster` renders cleanly; only the `memini` Cluster carries `postgresql.shared_preload_libraries: [vchord]`
- [ ] After merge, confirm bootstrap completes and the `memini` cluster reaches healthy with the `vchord` extension installed