### PR TITLE
feat(goat): deploy GOAT SRE sidekick to pitower

### DIFF
--- a/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/pitower/cloudnative-pg/cluster/cluster.yaml
@@ -336,6 +336,25 @@ spec:
   monitoring:
     enablePodMonitor: true
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: goat
+  namespace: cloudnative-pg
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:18
+  bootstrap:
+    initdb:
+      database: goat
+      owner: goat
+  storage:
+    size: 2Gi
+    storageClass: openebs-hostpath
+  monitoring:
+    enablePodMonitor: true
+---
 # CNPG's Cluster webhook parses spec.imageName's tag as a Postgres version
 # (e.g. "17.2") and rejects anything else, so tensorchord's "pg17-v0.5.1"
 # style tags can't be used directly there. A ClusterImageCatalog sidesteps

--- a/kubernetes/apps/pitower/goat/goat/kustomization.yaml
+++ b/kubernetes/apps/pitower/goat/goat/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: goat
+components:
+  - ../../../../components/cnpg-db
+configMapGenerator:
+  - name: cnpg-db-config
+    literals:
+      - APP_NAME=goat
+      - SECRET_NAME=goat-db-secret
+      - CNPG_SECRET_KEY=goat-app
+helmCharts:
+  - name: goat
+    repo: oci://ghcr.io/swibrow/charts
+    version: 0.1.0
+    releaseName: goat
+    valuesFile: values.yaml

--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -1,0 +1,45 @@
+# Home cluster (admin@pitower): everything in the goat namespace, secrets
+# synced from Infisical via the external-secrets ClusterSecretStore. Pin the
+# image by release version: spegel resolves mutable tags like :latest from
+# peer caches, serving stale images.
+#
+# goat-db-secret is the CNPG-generated app credential (see
+# cloudnative-pg/cluster/cluster.yaml + the cnpg-db kustomize component).
+image:
+  tag: v0.1.0
+database:
+  enabled: true
+  secret: goat-db-secret
+  secretKey: DB_URL
+api:
+  persistence:
+    size: 10Gi
+# Dev-session pods (Claude Code in the goat namespace) — needs the
+# ghcr.io/swibrow/claude-code image and the egress NetworkPolicy below.
+devSessions:
+  enabled: true
+secrets:
+  externalSecrets:
+    enabled: true
+    store: infisical
+    basePath: /goat
+    githubApp: true
+networkPolicy:
+  enabled: true
+httpRoute:
+  enabled: true
+  hostname: goat.wibrow.dev
+  gateway:
+    name: envoy-internal
+    namespace: networking
+    sectionName: https
+  # GitHub can't reach envoy-internal (VPN-only) to deliver App webhooks —
+  # route just /webhooks/* through envoy-external instead. Point the GitHub
+  # App's webhook URL at https://goat-hooks.wibrow.dev/webhooks/github.
+  webhookExternal:
+    enabled: true
+    hostname: goat-hooks.wibrow.dev
+    gateway:
+      name: envoy-external
+      namespace: networking
+      sectionName: https


### PR DESCRIPTION
Deploys GOAT v3 (swibrow/goat#14) following the garrison pattern:

- `kubernetes/apps/pitower/goat/goat/` — kustomization (cnpg-db component: `goat-db-secret` from `goat-app`) + values for the `goat` chart from `oci://ghcr.io/swibrow/charts` 0.1.0
- CNPG `goat` cluster (postgresql:18, 2 instances, 2Gi) in `cloudnative-pg/cluster/cluster.yaml`
- HTTPRoutes: `goat.wibrow.dev` (envoy-internal) + `goat-hooks.wibrow.dev` (envoy-external, `/webhooks` only)
- Secrets expected in Infisical under `/goat/*` (+ `/goat/github-app/*`)

Merge after the first goat release publishes the chart + image (`v0.1.0`). If the ghcr package is private, set `imagePullSecret: ghcr-pull-secret` in values.