### PR TITLE
feat(arc): add a per-repo runner scale set for garrison

### DIFF
--- a/kubernetes/apps/pitower/arc/garrison-runners/kustomization.yaml
+++ b/kubernetes/apps/pitower/arc/garrison-runners/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: arc
+resources:
+  - rbac.yaml
+helmCharts:
+  - name: gha-runner-scale-set
+    repo: oci://ghcr.io/actions/actions-runner-controller-charts
+    version: 0.14.2
+    releaseName: garrison-runners
+    namespace: arc
+    valuesFile: values.yaml

--- a/kubernetes/apps/pitower/arc/garrison-runners/rbac.yaml
+++ b/kubernetes/apps/pitower/arc/garrison-runners/rbac.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: garrison-runners
+  namespace: arc

--- a/kubernetes/apps/pitower/arc/garrison-runners/values.yaml
+++ b/kubernetes/apps/pitower/arc/garrison-runners/values.yaml
@@ -1,0 +1,36 @@
+# Per-repo runner scale set — ARC has no personal-account-wide scope, only
+# repo/org/enterprise, so a new repo means copying this directory and
+# changing githubConfigUrl, runnerScaleSetName, and releaseName/serviceAccountName.
+githubConfigUrl: https://github.com/swibrow/garrison
+githubConfigSecret: arc-github-app
+runnerScaleSetName: garrison
+
+controllerServiceAccount:
+  name: arc-gha-rs-controller
+  namespace: arc
+
+minRunners: 0
+maxRunners: 2
+
+containerMode:
+  type: dind
+
+template:
+  spec:
+    serviceAccountName: garrison-runners
+    automountServiceAccountToken: true
+    tolerations:
+      - key: dedicated
+        operator: Equal
+        value: storage
+        effect: NoSchedule
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:2.335.1
+        command: ["/home/runner/run.sh"]
+        resources:
+          requests:
+            cpu: 1
+            memory: 2Gi
+          limits:
+            memory: 4Gi


### PR DESCRIPTION
## Summary
- New ARC `RunnerScaleSet` at `kubernetes/apps/pitower/arc/garrison-runners/`, scoped to `swibrow/garrison` — swibrow/garrison#118 routes its amd64 image build here instead of GitHub-hosted `ubuntu-latest`, since GitHub-hosted matrix builds were too slow to ship a PR.
- Mirrors the existing `home-ops-runners` scale set, with two differences:
  - `containerMode: dind` enabled — garrison's job actually runs `docker buildx build`, unlike home-ops's own CI (which still builds on `ubuntu-latest`).
  - No `ClusterRoleBinding` to `view` — the build doesn't need k8s API access.
  - Bumped resources (`cpu: 1`, `2Gi`/`4Gi` mem) for the `bun install` + `bun run build` + image build workload.
- ARC has no personal-account-wide scope (only repo/org/enterprise for a personal GitHub account), so this is deliberately a per-repo scale set, structured so adding another repo later is copying this directory and changing `githubConfigUrl`/`runnerScaleSetName`/`serviceAccountName`.
- Dry-ran `kustomize build --enable-helm` locally to confirm the dind sidecar, socket volume, service account, tolerations, and resources all render correctly.

## Test plan
- [ ] Grant the `arc-github-app` GitHub App repository access to `swibrow/garrison` (Settings → Applications → installed app → Configure → Repository access) — required before the scale set can register runners
- [ ] Merge and confirm ArgoCD auto-creates/syncs the `pitower-arc-garrison-runners` Application
- [ ] Confirm the `AutoscalingRunnerSet` registers with GitHub and a garrison build picks up the `garrison` runner successfully