### PR TITLE
fix(argocd): auth ghcr.io OCI helm pulls via GitHub App installation token

### DIFF
--- a/kubernetes/bootstrap/kustomization.yaml
+++ b/kubernetes/bootstrap/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - appproject.yaml
   - externalsecret.yaml
   - pitower-cluster-secret.yaml
+  - repo-creds-ghcr.yaml
 
 helmCharts:
   - name: argo-cd

--- a/kubernetes/bootstrap/repo-creds-ghcr.yaml
+++ b/kubernetes/bootstrap/repo-creds-ghcr.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/generators.external-secrets.io/githubaccesstoken_v1alpha1.json
+# Mints short-lived (60 min, non-configurable) installation tokens from the
+# same GitHub App already used for argocd-repo-creds-github-swibrow (git
+# repo-creds). Scoped down to Packages:read on the goat repo only — that App
+# must have the "Packages" (read) permission granted and the goat repo in its
+# installation's repository access list, or minting fails.
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: GithubAccessToken
+metadata:
+  name: argocd-ghcr
+  namespace: argocd
+spec:
+  appID: "1320850"
+  installID: "68309201"
+  permissions:
+    packages: read
+  repositories:
+    - goat
+  auth:
+    privateKey:
+      secretRef:
+        name: argocd-repo-creds-github-swibrow
+        key: githubAppPrivateKey
+---
+# ArgoCD's OCI Helm pull path only understands username/password repo-creds
+# (no GitHub-App-aware code path like the git type has), so the minted
+# installation token is fed in as a password with the GitHub-documented
+# x-access-token username.
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-repo-creds-ghcr
+  namespace: argocd
+spec:
+  refreshInterval: 20m
+  target:
+    name: argocd-repo-creds-ghcr
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repo-creds
+      data:
+        url: ghcr.io/swibrow
+        name: swibrow-ghcr
+        type: helm
+        enableOCI: "true"
+        username: x-access-token
+        password: "{{ .token }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: GithubAccessToken
+          name: argocd-ghcr


### PR DESCRIPTION
## Summary
- ArgoCD couldn't sync `pitower-goat-goat` — `helm pull oci://ghcr.io/swibrow/charts/goat` 401'd because the package is private and ArgoCD had no ghcr.io repo-creds configured.
- Adds a `GithubAccessToken` ESO generator that mints a short-lived (60m) installation token from the existing `argocd` GitHub App (id `1320850`, install `68309201`), scoped to `packages: read` on the `goat` repo, reusing its already-deployed private key (`argocd-repo-creds-github-swibrow`).
- Renders that token into a `type: helm` / `enableOCI: true` repo-creds secret for the `ghcr.io/swibrow` URL prefix (username `x-access-token` per GitHub's convention), refreshed every 20 min — same pattern already used by `toolhive-config` for its GitHub App token.

Requires the App to have `Packages: Read-only` permission granted and `swibrow/goat` in its installation's repository access list (done manually in GitHub's UI, not part of this diff).

## Test plan
- [x] `kubectl kustomize kubernetes/bootstrap --enable-helm --load-restrictor LoadRestrictionsNone` builds cleanly
- [ ] After merge, confirm `pitower-goat-goat` ArgoCD Application syncs (chart pull succeeds, comparison error clears)