### PR TITLE
chore(goat): deploy v0.1.1

### DIFF
--- a/kubernetes/apps/pitower/goat/goat/kustomization.yaml
+++ b/kubernetes/apps/pitower/goat/goat/kustomization.yaml
@@ -12,6 +12,6 @@ configMapGenerator:
 helmCharts:
   - name: goat
     repo: oci://ghcr.io/swibrow/charts
-    version: 0.1.0
+    version: 0.1.1
     releaseName: goat
     valuesFile: values.yaml

--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -6,7 +6,7 @@
 # goat-db-secret is the CNPG-generated app credential (see
 # cloudnative-pg/cluster/cluster.yaml + the cnpg-db kustomize component).
 image:
-  tag: v0.1.0
+  tag: v0.1.1
 database:
   enabled: true
   secret: goat-db-secret


### PR DESCRIPTION
Manual catch-up deploy: goat chart/image were released as v0.1.1 but home-ops was still pinned to v0.1.0. Bumps helmCharts[0].version and image.tag.

This will be automated going forward by swibrow/goat's new deploy-pitower CI job once GOAT_APP_ID/GOAT_APP_PRIVATE_KEY secrets are set up.