### PR TITLE
fix(goat): wire up ghcr-pull-secret for image pulls

### DIFF
--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -7,6 +7,7 @@
 # cloudnative-pg/cluster/cluster.yaml + the cnpg-db kustomize component).
 image:
   tag: v0.1.1
+imagePullSecret: ghcr-pull-secret
 database:
   enabled: true
   secret: goat-db-secret


### PR DESCRIPTION
goat-api/goat-hooks pods are in ImagePullBackOff — ghcr.io/swibrow/goat is a private package and the deployment wasn't referencing an imagePullSecret. Sets `imagePullSecret: ghcr-pull-secret`, which the new cluster-wide ClusterExternalSecret fans into every namespace including goat.