### PR TITLE
chore(goat): deploy v0.2.0

### DIFF
--- a/kubernetes/apps/pitower/goat/goat/kustomization.yaml
+++ b/kubernetes/apps/pitower/goat/goat/kustomization.yaml
@@ -12,6 +12,6 @@ configMapGenerator:
 helmCharts:
   - name: goat
     repo: oci://ghcr.io/swibrow/charts
-    version: 0.1.1
+    version: 0.2.0
     releaseName: goat
     valuesFile: values.yaml

--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -6,7 +6,7 @@
 # goat-db-secret is the CNPG-generated app credential (see
 # cloudnative-pg/cluster/cluster.yaml + the cnpg-db kustomize component).
 image:
-  tag: v0.1.1
+  tag: v0.2.0
 imagePullSecret: ghcr-pull-secret
 database:
   enabled: true


### PR DESCRIPTION
Automated deploy of goat v0.2.0 (swibrow/goat@664f4dae8e87dad008a4b2bd439c519d92abd43d).

Fixes a startup crash: TypeError: connect() got an unexpected keyword argument 'sslmode' (asyncpg dialect forwarding CNPG's sslmode query param verbatim).

Opened manually because the goat-deploy GitHub App got a 403 pushing to this repo — see swibrow/goat CI run 29151463853, job deploy-pitower.