### PR TITLE
feat(arc): garrison runner image with tmux + unzip

### DIFF
--- a/docker/garrison-arc-runner/Dockerfile
+++ b/docker/garrison-arc-runner/Dockerfile
@@ -1,0 +1,14 @@
+# Self-hosted GitHub Actions runner for the swibrow/garrison repo's `garrison`
+# scale set. Stock actions-runner plus the two CLIs garrison's CI gates need
+# that the base image lacks: tmux (gate 4 drives a real tmux session) and
+# unzip (oven-sh/setup-bun extracts bun with it).
+# The first ARG *_VERSION drives the published image tag (see build-docker-images.yaml).
+ARG RUNNER_VERSION=2.335.1
+
+FROM ghcr.io/actions/actions-runner:${RUNNER_VERSION}
+
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tmux unzip \
+    && rm -rf /var/lib/apt/lists/*
+USER runner

--- a/kubernetes/apps/pitower/arc/garrison-runners/values.yaml
+++ b/kubernetes/apps/pitower/arc/garrison-runners/values.yaml
@@ -26,7 +26,7 @@ template:
         effect: NoSchedule
     containers:
       - name: runner
-        image: ghcr.io/actions/actions-runner:2.335.1
+        image: ghcr.io/swibrow/garrison-arc-runner:2.335.1
         command: ["/home/runner/run.sh"]
         resources:
           requests:


### PR DESCRIPTION
## What

Adds a thin custom runner image for the self-hosted `garrison` scale set and points the ARC values at it.

- `docker/garrison-arc-runner/Dockerfile` — `FROM ghcr.io/actions/actions-runner:2.335.1` + `tmux` and `unzip`.
- `garrison-runners/values.yaml` — runner image → `ghcr.io/swibrow/garrison-arc-runner:2.335.1`.

## Why

garrison's CI `gates` job is moving onto this self-hosted runner (swibrow/garrison PR to follow). The stock `actions-runner` image ships neither:
- **tmux** — garrison gate 4 (e2e) drives a real tmux session.
- **unzip** — `oven-sh/setup-bun` extracts bun with it.

The runner runs as the unprivileged `runner` user with no sudo, so these can't be `apt-get`'d at job runtime — they have to be baked in.

## Sequencing / notes

- On merge, `build-docker-images.yaml` builds+pushes `garrison-arc-runner:2.335.1` (docker/** changed), and flux reconciles the values change. `minRunners: 0`, so no runner pod pulls the new image until a job requests one — the garrison gates PR should only be triggered after this image is live.
- Image tag is driven by the first `ARG *_VERSION` per the repo convention; pinned to the runner version `2.335.1`.