### PR TITLE
fix(arc): add libatomic1 to garrison runner image

### DIFF
--- a/docker/garrison-arc-runner/Dockerfile
+++ b/docker/garrison-arc-runner/Dockerfile
@@ -1,14 +1,20 @@
 # Self-hosted GitHub Actions runner for the swibrow/garrison repo's `garrison`
-# scale set. Stock actions-runner plus the two CLIs garrison's CI gates need
-# that the base image lacks: tmux (gate 4 drives a real tmux session) and
-# unzip (oven-sh/setup-bun extracts bun with it).
+# scale set. Stock actions-runner plus what garrison's CI gates need that the
+# stripped-down base image lacks:
+#   - tmux       gate 4 drives a real tmux session
+#   - unzip      oven-sh/setup-bun extracts bun with it
+#   - libatomic1 the Node 26 that actions/setup-node installs links libatomic.so.1
 # The first ARG *_VERSION drives the published image tag (see build-docker-images.yaml).
+# IMAGE_VERSION is <runner-version>-<revision>: bump the revision whenever this
+# image's contents change without the base runner version moving, so the scale
+# set pulls a fresh tag instead of a cached one (default pull policy is IfNotPresent).
+ARG IMAGE_VERSION=2.335.1-1
 ARG RUNNER_VERSION=2.335.1
 
 FROM ghcr.io/actions/actions-runner:${RUNNER_VERSION}
 
 USER root
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends tmux unzip \
+    && apt-get install -y --no-install-recommends tmux unzip libatomic1 \
     && rm -rf /var/lib/apt/lists/*
 USER runner

--- a/kubernetes/apps/pitower/arc/garrison-runners/values.yaml
+++ b/kubernetes/apps/pitower/arc/garrison-runners/values.yaml
@@ -26,7 +26,7 @@ template:
         effect: NoSchedule
     containers:
       - name: runner
-        image: ghcr.io/swibrow/garrison-arc-runner:2.335.1
+        image: ghcr.io/swibrow/garrison-arc-runner:2.335.1-1
         command: ["/home/runner/run.sh"]
         resources:
           requests:


### PR DESCRIPTION
Follow-up to #1490. garrison gate 1 failed on the runner with `node: error while loading shared libraries: libatomic.so.1` — the Node 26 `actions/setup-node` installs links libatomic, absent from the stock actions-runner image. Adds `libatomic1` and bumps the image tag to `2.335.1-1` (base runner still 2.335.1) so the scale set pulls the new layer rather than the IfNotPresent-cached `2.335.1`.