### PR TITLE
feat(garrison): wire raid runners to toolhive MCP backends

### DIFF
--- a/kubernetes/apps/pitower/ai/toolhive/toolhive-config/networkpolicy.yaml
+++ b/kubernetes/apps/pitower/ai/toolhive/toolhive-config/networkpolicy.yaml
@@ -185,3 +185,41 @@ spec:
       ports:
         - protocol: TCP
           port: 4483
+---
+# Garrison raid agents (runner sandboxes in ns garrison) may call a curated
+# subset of the mcp-tools backend proxies directly — per-repo selection and
+# tool allowlists are enforced garrison-side, this is the network floor.
+# Deliberately excluded: kubernetes/argocd/aws-api/home-assistant/clickhouse
+# (privileged identities) and everything in mcp-secrets. NetworkPolicies are
+# additive, so this only widens ingress for the listed proxies; the
+# workload pods stay proxy-only. The egress half lives in the garrison
+# chart values (networkPolicy.runnerExtraEgress).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mcp-backend-proxy-from-garrison-runners
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: mcpserver
+    matchExpressions:
+      - key: toolhive-name
+        operator: In
+        values:
+          - github
+          - context7
+          - grafana
+          - terraform
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: garrison
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: garrison-runner
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -39,6 +39,21 @@ persistence:
   size: 5Gi
 networkPolicy:
   enabled: true
+  # Narrow exception to the runner sandboxes' private-range egress fence:
+  # the toolhive MCP backend proxies in the ai namespace (see mcp.catalog
+  # below). The other half is the garrison-runner ingress allowance in
+  # ai/toolhive/toolhive-config/networkpolicy.yaml.
+  runnerExtraEgress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ai
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: mcpserver
+      ports:
+        - protocol: TCP
+          port: 8080
 httpRoute:
   enabled: true
   hostname: garrison.wibrow.dev
@@ -56,3 +71,41 @@ httpRoute:
       name: envoy-external
       namespace: networking
       sectionName: https
+# Remote MCP servers raid agents may use, selected per project (wartable
+# checkboxes / herald /mcp / PATCH projects API). URLs are the toolhive
+# backend proxies in the ai namespace — reachable from runner pods only via
+# the runnerExtraEgress exception below plus the garrison-runner ingress in
+# ai/toolhive/toolhive-config/networkpolicy.yaml. The github entry ships a
+# read-only default tool allowlist (enforced in the runner by a PreToolUse
+# deny hook); a project can widen it by overriding `tools` in its selection.
+# NOTE: requires chart >= the release carrying mcp support — until the
+# version above is bumped past it, these keys are inert.
+mcp:
+  catalog:
+    - name: github
+      url: http://mcp-github-proxy.ai.svc.cluster.local:8080/mcp
+      description: GitHub repos/issues/PRs/actions (read-only default toolset)
+      tools:
+        - get_issue
+        - get_issue_comments
+        - list_issues
+        - search_issues
+        - get_pull_request
+        - get_pull_request_files
+        - get_pull_request_comments
+        - list_pull_requests
+        - search_code
+        - get_file_contents
+        - list_workflow_runs
+        - get_workflow_run
+        - get_job_logs
+    - name: context7
+      url: http://mcp-context7-proxy.ai.svc.cluster.local:8080/mcp
+      description: Library documentation lookup (resolve-library-id, get-library-docs)
+    - name: grafana
+      url: http://mcp-grafana-proxy.ai.svc.cluster.local:8080/sse
+      transport: sse
+      description: Grafana dashboards, Prometheus/Loki queries
+    - name: terraform
+      url: http://mcp-terraform-proxy.ai.svc.cluster.local:8080/mcp
+      description: Terraform registry providers/modules docs


### PR DESCRIPTION
Companion to the garrison MCP-support change (branch `mcp` on swibrow/garrison — per-repo MCP server selection for raid agents).

## What
- **`garrison/values.yaml`**: `mcp.catalog` with four curated servers — **github** (read-only default tool allowlist), **context7**, **grafana**, **terraform** — pointing at the toolhive backend proxies in `ai`; plus `networkPolicy.runnerExtraEgress` opening runner-sandbox egress to those proxies (the runner egress policy otherwise fences off all private ranges).
- **`ai/toolhive/toolhive-config/networkpolicy.yaml`**: new `mcp-backend-proxy-from-garrison-runners` policy admitting pods labelled `app.kubernetes.io/name=garrison-runner` from ns `garrison` to those same four proxies on 8080. Privileged backends (kubernetes, argocd, aws-api, home-assistant, clickhouse) and the mcp-secrets group stay vMCP-only.

## Ordering
These values keys are **inert until a garrison release ships MCP support** and `helmCharts[0].version` is bumped past it (deploy-pitower CI only auto-patches version + image tags — this PR carries the new keys manually, per the usual chart-values gotcha). The NetworkPolicy half is safe to merge any time.

## After merge
Per-project selection happens on the keep (wartable project form checkboxes, herald `/mcp <project> toggle <server>`, or `PATCH /api/v1/projects/:id`). Nothing gets MCP access until a project opts in.