### PR TITLE
fix(arc): raise garrison runner memory to 8Gi

### DIFF
--- a/kubernetes/apps/pitower/arc/garrison-runners/values.yaml
+++ b/kubernetes/apps/pitower/arc/garrison-runners/values.yaml
@@ -31,6 +31,6 @@ template:
         resources:
           requests:
             cpu: 1
-            memory: 2Gi
-          limits:
             memory: 4Gi
+          limits:
+            memory: 8Gi


### PR DESCRIPTION
Follow-up to #1490/#1499. garrison's `gates` job OOMKilled on the runner during gate 3 (`bun run test:coverage`, whole monorepo) at the 4Gi limit — confirmed `lastState.terminated.reason=OOMKilled`, pod phase Failed. Raises limit 4Gi→8Gi, request 2Gi→4Gi. No image change; pod-resources only.