### PR TITLE
fix(arc): set UTF-8 locale in garrison runner image

### DIFF
--- a/docker/garrison-arc-runner/Dockerfile
+++ b/docker/garrison-arc-runner/Dockerfile
@@ -4,11 +4,14 @@
 #   - tmux       gate 4 drives a real tmux session
 #   - unzip      oven-sh/setup-bun extracts bun with it
 #   - libatomic1 the Node 26 that actions/setup-node installs links libatomic.so.1
+# LANG=C.UTF-8: the base image leaves the locale unset, so tmux mangles the
+# non-ASCII pane titles (✳ / braille spinner) garrison's status discovery keys
+# on — a UTF-8 locale keeps them intact.
 # The first ARG *_VERSION drives the published image tag (see build-docker-images.yaml).
 # IMAGE_VERSION is <runner-version>-<revision>: bump the revision whenever this
 # image's contents change without the base runner version moving, so the scale
 # set pulls a fresh tag instead of a cached one (default pull policy is IfNotPresent).
-ARG IMAGE_VERSION=2.335.1-1
+ARG IMAGE_VERSION=2.335.1-2
 ARG RUNNER_VERSION=2.335.1
 
 FROM ghcr.io/actions/actions-runner:${RUNNER_VERSION}
@@ -17,4 +20,5 @@ USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends tmux unzip libatomic1 \
     && rm -rf /var/lib/apt/lists/*
+ENV LANG=C.UTF-8
 USER runner

--- a/kubernetes/apps/pitower/arc/garrison-runners/values.yaml
+++ b/kubernetes/apps/pitower/arc/garrison-runners/values.yaml
@@ -26,7 +26,7 @@ template:
         effect: NoSchedule
     containers:
       - name: runner
-        image: ghcr.io/swibrow/garrison-arc-runner:2.335.1-1
+        image: ghcr.io/swibrow/garrison-arc-runner:2.335.1-2
         command: ["/home/runner/run.sh"]
         resources:
           requests:


### PR DESCRIPTION
Follow-up to #1490/#1499/#1501, the last gap for garrison gates on the self-hosted runner. Gate 4's 'discovers a claude-titled pane' test failed because the stock runner leaves the locale unset, so tmux mangles the `✳` pane title that `status` discovery keys on (`title.startsWith('✳')`) → 0 agents. Verified inside `garrison-arc-runner:2.335.1-1`: `LANG` unset → title byte `0x5f` ('_'); `LANG=C.UTF-8` → `e2 9c b3` (✳). Adds `ENV LANG=C.UTF-8` and bumps the tag to `2.335.1-2`.