### PR TITLE
feat(toolhive): enable refresh tokens on the OAuth MCP gateways

### DIFF
--- a/kubernetes/apps/pitower/ai/toolhive/toolhive-config/virtualmcpserver-secrets.yaml
+++ b/kubernetes/apps/pitower/ai/toolhive/toolhive-config/virtualmcpserver-secrets.yaml
@@ -22,12 +22,16 @@ spec:
     name: mcp-tools-embedding
   authServerConfig:
     issuer: https://mcp-secrets.wibrow.dev
+    # offline_access → rotating refresh tokens = no re-auth while actively used.
+    # Must also appear in incomingAuth scopes below (feeds scopes_supported).
+    # See virtualmcpserver.yaml for the full rationale.
     baselineClientScopes:
       - openid
-    # Operator hard-caps access token at 24h (see virtualmcpserver.yaml).
+      - offline_access
+    # Operator caps: access 24h, refresh 720h (see virtualmcpserver.yaml).
     tokenLifespans:
       accessTokenLifespan: 24h
-      refreshTokenLifespan: 24h
+      refreshTokenLifespan: 720h
     # Shared signing/HMAC material with the other ASes.
     signingKeySecretRefs:
       - name: toolhive-authserver-secret
@@ -56,11 +60,15 @@ spec:
         oidcConfig:
           issuerUrl: https://idm.wibrow.dev/oauth2/openid/toolhive-mcp
           clientId: toolhive-mcp
+          # offline_access: kanidm refresh token for the upstream session, else
+          # enrichment 401s once the kanidm access token expires (see
+          # virtualmcpserver.yaml).
           scopes:
             - openid
             - profile
             - email
             - groups
+            - offline_access
   incomingAuth:
     type: oidc
     oidcConfigRef:
@@ -68,11 +76,14 @@ spec:
       # Trailing slash is load-bearing (RFC 8707 resource match) — see virtualmcpserver.yaml.
       audience: https://mcp-secrets.wibrow.dev/
       resourceUrl: https://mcp-secrets.wibrow.dev/
+      # Advertised, not enforced — becomes the AS's scopes_supported; must
+      # include offline_access (see virtualmcpserver.yaml).
       scopes:
         - openid
         - profile
         - email
         - groups
+        - offline_access
     # Group gating happens at the kanidm scope-map; Cedar just allows authenticated calls.
     authzConfig:
       type: inline

--- a/kubernetes/apps/pitower/ai/toolhive/toolhive-config/virtualmcpserver.yaml
+++ b/kubernetes/apps/pitower/ai/toolhive/toolhive-config/virtualmcpserver.yaml
@@ -30,33 +30,31 @@ spec:
     # Issuer = the public root URL of the aggregate. The AS advertises its
     # endpoints under it (…/oauth/authorize, …/token, …/register).
     issuer: https://mcp.wibrow.dev
-    # Scopes every DCR-registered client may request. Keep narrow — granted to
-    # ALL dynamically-registered clients; kanidm's toolhive-mcp advertises only
-    # openid/profile/email/groups (no offline_access), so just openid here.
+    # Scopes every DCR-registered client may request. Keep narrow — unioned into
+    # ALL dynamically-registered clients' scope sets (RFC 7591 §3.2.1), so each
+    # entry here is requestable at /oauth/authorize by every DCR client.
     #
-    # NOTE: offline_access CANNOT be added here on this operator version. The AS
-    # derives scopes_supported from the upstream provider but STRIPS
-    # offline_access (it's a token-issuance scope, not a discoverable OIDC
-    # scope), and there is no explicit scopesSupported override field in this
-    # CRD. The AS hard-fails to start: "baseline_client_scopes contains
-    # offline_access which is not in scopes_supported". Supporting offline_access
-    # would require a toolhive operator upgrade to a version exposing
-    # scopesSupported. Verified 2026-06-15.
+    # offline_access is what makes the AS mint refresh tokens (fosite only
+    # issues one when the granted scope includes it). Since operator v0.30 the
+    # AS no longer strips offline_access from scopes_supported — instead
+    # scopes_supported is derived verbatim from incomingAuth.oidcConfigRef
+    # scopes, so offline_access MUST also be listed there or the AS hard-fails
+    # to start ("baseline_client_scopes contains offline_access which is not in
+    # scopes_supported"). Verified against v0.34.0 source.
     baselineClientScopes:
       - openid
-    # Token lifetimes. Because offline_access can't be granted (see note above),
-    # MCP clients like Claude Code never get a usable refresh token — so the
-    # access-token lifespan IS the effective session length before re-auth. The
-    # default 1h forces near-constant re-auth.
+      - offline_access
+    # Token lifetimes. With offline_access grantable, clients get rotating
+    # refresh tokens: each /oauth/token refresh mints a new refresh token valid
+    # for refreshTokenLifespan, and the token endpoint also renews the DCR
+    # client-registration TTL on every exchange — so an actively-used client
+    # never re-auths. Re-auth only after 30 days of complete inactivity.
     #
-    # The operator HARD-CAPS the access token at 24h: a longer value fails
-    # validation and crashloops the vMCP on boot ("access token lifespan must be
-    # between 1m0s and 24h0m0s"). 720h (the earlier 30d attempt) is invalid — 24h
-    # is the ceiling, still 24× the 1h default. refresh kept equal (it's unusable
-    # anyway without offline_access). Defaults if unset: access 1h, refresh 7d.
+    # Operator caps (v0.34.0): access 1m–24h, refresh 1h–720h. Longer values
+    # fail validation and crashloop the vMCP on boot.
     tokenLifespans:
       accessTokenLifespan: 24h
-      refreshTokenLifespan: 24h
+      refreshTokenLifespan: 720h
     # Persistent signing (RS256) + HMAC material — shared with the per-server
     # ASes via externalsecret.yaml → Secret toolhive-authserver-secret. Without
     # these the AS auto-gens ephemeral keys and restarts invalidate tokens.
@@ -90,11 +88,19 @@ spec:
         oidcConfig:
           issuerUrl: https://idm.wibrow.dev/oauth2/openid/toolhive-mcp
           clientId: toolhive-mcp
+          # offline_access here gets the AS a kanidm REFRESH token at login.
+          # Without it, once the kanidm access token stored for the session
+          # expires, the incoming-auth upstream-token enrichment fails refresh
+          # and 401s EVERY request — even while the AS-issued token is still
+          # valid. Requires offline_access in the toolhive-mcp client's kanidm
+          # scope-map for the mcp-tools group (kanidm rejects unmapped scopes
+          # at authorize).
           scopes:
             - openid
             - profile
             - email
             - groups
+            - offline_access
   incomingAuth:
     type: oidc
     # Validate the tokens the embedded AS itself issues (issuer/audience match
@@ -113,11 +119,18 @@ spec:
       name: mcp-gateway-oidc
       audience: https://mcp.wibrow.dev/
       resourceUrl: https://mcp.wibrow.dev/
+      # These scopes are NOT enforced on incoming tokens — they feed two
+      # advertisements: the AS's scopes_supported (openid-configuration; the
+      # operator derives it from this list verbatim) and the RFC 9728
+      # protected-resource metadata clients read to decide what to request.
+      # offline_access must be listed here for DCR to accept it and for the
+      # baselineClientScopes subset check to pass at AS startup.
       scopes:
         - openid
         - profile
         - email
         - groups
+        - offline_access
     # Group gating happens at kanidm, NOT in Cedar: kanidm never emits group
     # claims in the access token Cedar evaluates, so THVGroup policies would
     # deny-all. The toolhive-mcp client's kanidm scope-map is restricted to the


### PR DESCRIPTION
## Summary
- Add `offline_access` to both OAuth vMCPs (`mcp-gateway`, `mcp-gateway-secrets`) in three places: `incomingAuth` scopes (becomes the embedded AS's `scopes_supported` + RFC 9728 metadata), `baselineClientScopes` (every DCR client may request it), and the kanidm upstream scopes (AS obtains a kanidm refresh token; without it, upstream-token enrichment 401s every request once the stored kanidm access token expires).
- Raise `refreshTokenLifespan` to 720h (operator max). Refresh tokens rotate on use and the token endpoint renews the DCR client-registration TTL on every exchange, so actively-used clients never re-auth; re-auth only after 30 days idle.
- Unblocked by operator v0.30+ (running v0.34.0): the embedded AS no longer strips `offline_access` — `scopes_supported` is now derived verbatim from the incomingAuth scopes.

Kanidm side verified ready: `toolhive-mcp`'s `mcp-tools` scope-map already contains `offline_access`.

## Rollout notes
- **Existing DCR registrations break**: fosite's `ExactScopeStrategy` rejects clients requesting a scope they didn't register with. Delete + re-add the claude.ai Home Ops connector and the Claude Code MCP entry after the vMCPs roll (plain re-authorize fails with `invalid_scope`).
- Side effect: the AS now always requests `offline_access` upstream, and only `mcp-tools` members can be granted it — persons outside `mcp-tools` get `access_denied` at kanidm (restores members-only gating despite the `idm_all_persons` scope-map).

## Test plan
- [ ] `curl -s https://mcp.wibrow.dev/.well-known/oauth-authorization-server | jq .scopes_supported` lists `offline_access` (same for mcp-secrets.wibrow.dev)
- [ ] vMCP pods roll cleanly (no `baseline_client_scopes` startup crashloop)
- [ ] Re-add Claude Code MCP entry → token response contains `refresh_token`
- [ ] Re-add claude.ai Home Ops connector → auth completes, session survives >24h without re-prompt