### PR TITLE
feat(garrison): enable the warhorn (Discord surface)

### DIFF
--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -26,6 +26,14 @@ launcher: sandbox
 herald:
   enabled: true
   allowedChatIds: "1053711635,-5540433154"
+# Discord surface. Bot token, application id, and the guild allowlist all
+# sync from Infisical (/garrison/WARHORN_*) via external-secrets — nothing
+# warhorn-specific to pin here. stt stays off until a transcription
+# endpoint is picked; the bot is text-only and /join says so.
+# NOTE: requires chart >= the release carrying the warhorn — until the
+# version above is bumped past it, these keys are inert.
+warhorn:
+  enabled: true
 secrets:
   authEnabled: true
   # wartable is VPN-only (envoy-internal); /internal stays token-gated.


### PR DESCRIPTION
## Summary

Enables the warhorn — garrison's new Discord surface (swibrow/garrison#154) — on pitower.

- `warhorn.enabled: true` only: the bot token, application id, **and guild allowlist** all sync from Infisical (`/garrison/WARHORN_BOT_TOKEN`, `WARHORN_APPLICATION_ID`, `WARHORN_ALLOWED_GUILD_IDS`) via the existing external-secrets store, so nothing warhorn-specific is pinned in values. All three keys are already present in Infisical.
- With `database.enabled: true` already on, the warhorn comes up HA: 2 replicas, leader-elected Discord gateway session, state in Postgres schema `warhorn` (migrations applied at boot), transactional outbox.
- Voice (STT) stays off for now — the bot is text-only and `/join` says so; flipping it on later is `warhorn.stt.{enabled,url,model}` + `WARHORN_STT_KEY` in Infisical.
- These keys are **inert until the chart pin passes the release carrying the warhorn** — garrison's `deploy-pitower` bumps `kustomization.yaml`/image tags automatically when the next release cuts, and this activates then.

## Test plan
- [x] Chart renders with `warhorn.enabled=true` + `secrets.externalSecrets.enabled=true` (validated in garrison repo: deployment, ExternalSecret with the three `/garrison/WARHORN_*` refs, no PVC in database mode)
- [ ] After the garrison release bump: `garrison-warhorn` pods Ready, ExternalSecret Synced, bot answers `/help` in the allowlisted guild