### PR TITLE
feat(goat): enable the Discord surface (chart/image 0.8.0)

### DIFF
--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -21,12 +21,10 @@ api:
     ALLOWED_USERS: "1053711635"
     ADMIN_USERS: "1053711635"
     # Discord auth: "*" admits any member of the guilds listed below
-    # (DMs still need an explicit user ID). Fill in the guild ID before
-    # merging — "*" with an empty guild list opens the bot to every server
-    # it is in. Token synced from Infisical /goat/DISCORD_BOT_TOKEN via
-    # externalSecrets.discord below.
+    # (DMs still need an explicit user ID). Token synced from Infisical
+    # /goat/DISCORD_BOT_TOKEN via externalSecrets.discord below.
     DISCORD_ALLOWED_USERS: "*"
-    DISCORD_ALLOWED_GUILDS: ""
+    DISCORD_ALLOWED_GUILDS: "1528038323401261226"
     # goat-api has no egress restrictions, so it reaches the collector
     # directly — no auth needed. Dev-session pods are built with an explicit
     # V1EnvVar list (no envFrom) and don't currently forward this; wiring

--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -20,10 +20,13 @@ api:
   env:
     ALLOWED_USERS: "1053711635"
     ADMIN_USERS: "1053711635"
-    # Discord allow-list (numeric Discord user IDs) — same fail-closed rule.
-    # Token synced from Infisical /goat/DISCORD_BOT_TOKEN via
+    # Discord auth: "*" admits any member of the guilds listed below
+    # (DMs still need an explicit user ID). Fill in the guild ID before
+    # merging — "*" with an empty guild list opens the bot to every server
+    # it is in. Token synced from Infisical /goat/DISCORD_BOT_TOKEN via
     # externalSecrets.discord below.
-    DISCORD_ALLOWED_USERS: ""
+    DISCORD_ALLOWED_USERS: "*"
+    DISCORD_ALLOWED_GUILDS: ""
     # goat-api has no egress restrictions, so it reaches the collector
     # directly — no auth needed. Dev-session pods are built with an explicit
     # V1EnvVar list (no envFrom) and don't currently forward this; wiring

--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -20,6 +20,10 @@ api:
   env:
     ALLOWED_USERS: "1053711635"
     ADMIN_USERS: "1053711635"
+    # Discord allow-list (numeric Discord user IDs) — same fail-closed rule.
+    # Token synced from Infisical /goat/DISCORD_BOT_TOKEN via
+    # externalSecrets.discord below.
+    DISCORD_ALLOWED_USERS: ""
     # goat-api has no egress restrictions, so it reaches the collector
     # directly — no auth needed. Dev-session pods are built with an explicit
     # V1EnvVar list (no envFrom) and don't currently forward this; wiring
@@ -45,6 +49,7 @@ secrets:
     store: infisical
     basePath: /goat
     githubApp: true
+    discord: true
 networkPolicy:
   enabled: true
 httpRoute:


### PR DESCRIPTION
Companion to swibrow/goat#35 — enables the new Discord adapter on pitower.

- Bumps the goat chart + image to `0.8.0` / `v0.8.0` (the release that ships the Discord adapter — **merge only after that release exists**, otherwise ArgoCD can't pull the chart).
- `secrets.externalSecrets.discord: true` adds `DISCORD_BOT_TOKEN` to the `goat-secrets` Infisical sync.
- Adds `api.env.DISCORD_ALLOWED_USERS` (fail-closed: empty rejects every message).

## Manual steps before/at merge
1. Create a Discord application + bot at https://discord.com/developers/applications, enable the **Message Content** privileged intent, and invite the bot to your server (scope `bot`, permissions: send messages / read message history) or DM it.
2. Put the bot token in Infisical at `/goat/DISCORD_BOT_TOKEN` — the ExternalSecret sync fails wholesale if the key is missing.
3. Set `DISCORD_ALLOWED_USERS` in `values.yaml` to your numeric Discord user ID (Discord → Settings → Advanced → Developer Mode → right-click your name → Copy User ID).