### PR TITLE
feat(goat): enable changelog scanning for user:swibrow

### DIFF
--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -30,6 +30,13 @@ api:
     # V1EnvVar list (no envFrom) and don't currently forward this; wiring
     # them needs a code change in goat's dev_sessions/manager.py.
     OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector.monitoring.svc.cluster.local:4318
+    # Changelog scanning (goat >= 0.10): hourly REST sweep of every repo the
+    # PAT can read — the fallback for orgs without the GitHub App/webhooks.
+    # Backfill 0 = full history on the first sweep; GITHUB_LOGIN scopes
+    # /v1/stats/shipping to my own shipped changes by default.
+    GITHUB_SCAN_TARGETS: "user:swibrow"
+    GITHUB_SCAN_BACKFILL_DAYS: "0"
+    GITHUB_LOGIN: swibrow
 # Dev-session pods (Claude Code in the goat namespace) — needs the
 # ghcr.io/swibrow/claude-code image and the egress NetworkPolicy below.
 devSessions:


### PR DESCRIPTION
## Summary
- `GITHUB_SCAN_TARGETS=user:swibrow` — hourly `github-scan` job sweeps every repo the PAT can read and records shipped changes as changelog entries, no webhooks/App install needed (swibrow/goat#44)
- `GITHUB_SCAN_BACKFILL_DAYS=0` — full history on the first sweep (older entries skip agent review, categorized from conventional-commit titles)
- `GITHUB_LOGIN=swibrow` — default author for `/v1/stats/shipping` (web /shipping page, `goat stats`, `/stats`, `!stats`)

Merge after goat#44 releases and CI bumps the chart/image here — until then the env vars are inert (goat 0.9.0 ignores them).

## Test plan
- [ ] goat pod restarts clean with the new env
- [ ] `goat changelog scan` (or wait for the :15 hourly tick) fills `/v1/changelog` with history
- [ ] `/shipping` page shows weekly stats for swibrow