### PR TITLE
fix(goat): enable cluster-sentinel RBAC

### DIFF
--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -41,6 +41,10 @@ api:
 # ghcr.io/swibrow/claude-code image and the egress NetworkPolicy below.
 devSessions:
   enabled: true
+# Cluster-wide read-only RBAC for the cluster-sentinel job (pods, nodes,
+# PVCs, Rook-Ceph health). Without this the job 403s every 15 minutes.
+sentinel:
+  enabled: true
 # Web SPA auth via kanidm (OIDC). Client 'goat' bootstrapped with
 # scripts/bootstrap_kanidm.sh. Access is gated at kanidm's own scope-map
 # (oauth2_rs_scope_map: app_access), same as every other self-hosted app on


### PR DESCRIPTION
## Summary
- `sentinel.enabled` was never set for the goat Helm release, so the chart's `ClusterRole`/`ClusterRoleBinding` (pods/nodes/PVCs/CephCluster read access) was never applied.
- The `cluster-sentinel` scheduled job has been 403ing on every 15-minute run since it was added, and each failure is sent as an alert (`⚠ Scheduled job 'cluster-sentinel' failed: (403)`), spamming every 15 min.
- Setting `sentinel.enabled: true` deploys the RBAC so the job can actually read cluster state.

## Test plan
- [ ] ArgoCD syncs, `kubectl get clusterrole goat-sentinel` / `clusterrolebinding goat-sentinel` exist
- [ ] `kubectl -n goat logs deploy/goat-api` shows `cluster-sentinel` completing without 403 on the next 15-min tick
- [ ] No more repeated failure alerts