### PR TITLE
feat(proxmox): add garage s3 node as an lxc container

### DIFF
--- a/terraform/proxmox/README.md
+++ b/terraform/proxmox/README.md
@@ -1,6 +1,6 @@
 # terraform/proxmox
 
-Manages VM lifecycle on the `proxmox-01` hypervisor via the
+Manages VM and LXC container lifecycle on the `proxmox-01` hypervisor via the
 [`bpg/proxmox`](https://registry.terraform.io/providers/bpg/proxmox/latest/docs) provider.
 Host-level config (repos, fail2ban) is handled separately by Ansible - see `ansible/README.md`'s
 `proxmox-01` runbook.
@@ -9,6 +9,27 @@ Scope boundary: this stack creates the VM shell (CPU/memory/disk/NIC) and attach
 installer ISO. It does **not** configure Talos itself - the VM boots into Talos maintenance mode,
 and from there it's `talosctl apply-config` + a `talos/pitower/node/<host>/` topf layer, same as
 the bare-metal workers.
+
+## Garage S3 (`ct_garage.tf`)
+
+An LXC container, not a VM: Garage is a single static binary with no kernel requirements, so a VM
+would only add a guest kernel and a virtual disk layer between it and the ZFS pool. The 500G data
+volume is a mount point at `/var/lib/garage` (a plain ZFS dataset), separate from the 16G rootfs -
+the container can be rebuilt without touching data, and the dataset snapshots/replicates on its own.
+Sizing lives in the `garage` variable.
+
+Same scope boundary as the VMs: Terraform creates the container + data volume and injects your SSH
+key; installing and configuring Garage is Ansible's job. Networking is DHCP on VLAN 20 (via
+`vmbr0`, untagged from the guest's perspective) - pin the lease with a UniFi reservation using
+`terraform output garage_mac_address`, same as `nut` and `proxmox-01`.
+
+Before applying, verify `lxc_template_url` still resolves - Proxmox rolls the Debian template's
+point release and drops old ones. Check with `pveam available --section system` on the host and bump
+the variable if the exact filename has moved on.
+
+This node is intended as one replica of a multi-node Garage layout; a second replica is planned on
+the Synology NAS. Garage wants an odd number of nodes for quorum on metadata, so plan for a third
+(or a lightweight tiebreaker) before relying on it for anything that can't be re-derived.
 
 ## Credentials
 

--- a/terraform/proxmox/ct_garage.tf
+++ b/terraform/proxmox/ct_garage.tf
@@ -1,0 +1,82 @@
+# Garage S3 node, as an LXC container rather than a VM: Garage is a single
+# static binary with no kernel requirements, so a full VM only adds a guest
+# kernel and a virtual disk layer between it and the ZFS pool. The 500G data
+# volume is a plain ZFS dataset the host can snapshot/replicate directly.
+#
+# Scope boundary is the same as the VMs here: this creates the container
+# shell + data volume. Installing and configuring Garage itself belongs in
+# ansible/ (see README.md).
+
+resource "proxmox_download_file" "debian_lxc_template" {
+  content_type = "vztmpl"
+  datastore_id = var.iso_storage
+  node_name    = var.proxmox_node
+  url          = var.lxc_template_url
+}
+
+resource "proxmox_virtual_environment_container" "garage" {
+  node_name = var.proxmox_node
+  vm_id     = var.garage.vmid
+
+  description   = "Garage S3 node - managed by terraform/proxmox"
+  unprivileged  = true
+  start_on_boot = true
+  started       = true
+
+  operating_system {
+    template_file_id = proxmox_download_file.debian_lxc_template.id
+    type             = "debian"
+  }
+
+  cpu {
+    cores = var.garage.cores
+  }
+
+  memory {
+    dedicated = var.garage.memory
+    swap      = 0
+  }
+
+  disk {
+    datastore_id = var.disk_storage
+    size         = var.garage.root_disk
+  }
+
+  # Garage's metadata (LMDB) and data blocks both live under /var/lib/garage.
+  # Kept off the rootfs so the container can be rebuilt without touching data,
+  # and so the dataset can be snapshotted/replicated on its own.
+  mount_point {
+    volume = var.disk_storage
+    size   = "${var.garage.data_disk}G"
+    path   = "/var/lib/garage"
+    backup = false
+  }
+
+  network_interface {
+    name   = "eth0"
+    bridge = var.network_bridge
+    # No vlan_id, same reason as the VMs: vmbr0 already carries VLAN20 as a
+    # flat tag on the host side (nic1.20 -> vmbr0).
+  }
+
+  initialization {
+    hostname = var.garage.name
+
+    ip_config {
+      ipv4 {
+        address = "dhcp"
+      }
+    }
+
+    user_account {
+      keys = local.ssh_public_keys
+    }
+  }
+
+  # Terraform hands off after first boot; ansible manages the guest from there.
+  lifecycle {
+    ignore_changes = [
+      initialization[0].user_account, # rotating keys in-guest shouldn't recreate the CT
+    ]
+  }
+}

--- a/terraform/proxmox/outputs.tf
+++ b/terraform/proxmox/outputs.tf
@@ -7,3 +7,13 @@ output "talos_worker_mac_address" {
   description = "NIC MAC address - pin this in talos/pitower/topf.yaml's node entry once the VM boots"
   value       = proxmox_virtual_environment_vm.talos_worker.network_device[0].mac_address
 }
+
+output "garage_container_id" {
+  description = "Proxmox VMID of the Garage S3 LXC container"
+  value       = proxmox_virtual_environment_container.garage.vm_id
+}
+
+output "garage_mac_address" {
+  description = "eth0 MAC address - pin the DHCP lease to it with a UniFi reservation"
+  value       = proxmox_virtual_environment_container.garage.network_interface[0].mac_address
+}

--- a/terraform/proxmox/variables.tf
+++ b/terraform/proxmox/variables.tf
@@ -51,3 +51,42 @@ variable "talos_worker" {
     disk   = 1000
   }
 }
+
+variable "lxc_template_url" {
+  description = "Debian LXC template to base containers on - verify the exact filename exists with `pveam available --section system` on the host before applying"
+  type        = string
+  default     = "http://download.proxmox.com/images/system/debian-13-standard_13.1-2_amd64.tar.zst"
+}
+
+variable "ssh_public_keys" {
+  description = "SSH public keys injected into container root accounts. Defaults to the operator's local ~/.ssh/id_ed25519.pub"
+  type        = list(string)
+  default     = null
+}
+
+variable "garage" {
+  description = "Garage S3 LXC sizing. data_disk is the /var/lib/garage mount point (metadata + blocks); root_disk is just the Debian rootfs"
+  type = object({
+    vmid      = number
+    name      = string
+    cores     = number
+    memory    = number # MiB
+    root_disk = number # GiB
+    data_disk = number # GiB
+  })
+  default = {
+    vmid      = 210
+    name      = "garage-01"
+    cores     = 4
+    memory    = 4096
+    root_disk = 16
+    data_disk = 500
+  }
+}
+
+locals {
+  ssh_public_keys = coalesce(
+    var.ssh_public_keys,
+    compact([trimspace(try(file(pathexpand("~/.ssh/id_ed25519.pub")), ""))]),
+  )
+}


### PR DESCRIPTION
## Summary

Adds `terraform/proxmox/ct_garage.tf` — a Garage S3 node on `proxmox-01`.

- **LXC, not a VM.** Garage is a single static binary with no kernel requirements, so a VM would only add a guest kernel and a virtual disk layer between it and the ZFS pool. The container also lets the data volume be a plain ZFS dataset the host can snapshot and `zfs send` directly, which matters for the planned Synology replica.
- `garage-01`, VMID 210, unprivileged, 4 cores / 4GB, Debian 13 template.
- 16G rootfs + a **separate 500G mount point at `/var/lib/garage`** (`backup = false`) — metadata and blocks off the rootfs, so the container can be rebuilt without touching data.
- DHCP on `vmbr0` (already VLAN 20 untagged from the guest's perspective, same as the VMs here); `~/.ssh/id_ed25519.pub` injected.
- Sizing in a `garage` variable; outputs for VMID and MAC.

Same scope boundary as the existing VMs in this stack: Terraform creates the container shell and data volume, Ansible configures the guest. No Ansible role yet.

## Notes

- `local-zfs` has `sparse` set, so the 500G is a **refquota ceiling, not an allocation** — verified on the host (worker-07's 1000G zvol currently uses 176G, `refreservation none`). Pool has 1.93T available.
- Worst case if both fill: 1000G (worker-07) + 500G (garage) ≈ 78% of the pool, i.e. essentially all the headroom ZFS wants. Growing a refquota is online and non-destructive; shrinking is not — so starting lower is the safer call if that's uncomfortable.
- Garage wants an odd node count for metadata quorum. This node plus the Synology replica is two — a third or a tiebreaker is needed before it holds anything that can't be re-derived.

## Test plan

- [ ] `terraform validate` passes (green in pre-commit; also run standalone)
- [ ] Verify `lxc_template_url` still resolves — `pveam available --section system` on the host; Proxmox rolls the Debian point release and drops old files
- [ ] `zpool list rpool` to confirm headroom before applying
- [ ] `terraform plan` reviewed (blocked locally on an expired AWS session for the S3 state backend)
- [ ] Apply, confirm container boots and SSH works
- [ ] Confirm `/var/lib/garage` is mounted and reports ~500G
- [ ] Pin the DHCP lease via UniFi reservation using `terraform output garage_mac_address`