### PR TITLE
feat(goat): configure RENOVATE_REPOS for the renovate digest

### DIFF
--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -37,6 +37,9 @@ api:
     GITHUB_SCAN_TARGETS: "user:swibrow,DND-IT,tx-pts-dai,20minuten"
     GITHUB_SCAN_BACKFILL_DAYS: "0"
     GITHUB_LOGIN: swibrow
+    # Renovate concierge (weekday morning digest of bot PRs). owner/* expands
+    # to every repo of that org or user (goat >= 0.13).
+    RENOVATE_REPOS: "swibrow/*,cloudsnacks/*,propagit-dev/*"
 # Dev-session pods (Claude Code in the goat namespace) — needs the
 # ghcr.io/swibrow/claude-code image and the egress NetworkPolicy below.
 devSessions:


### PR DESCRIPTION
## Summary
Sets `RENOVATE_REPOS` for goat's weekday renovate concierge (bot-PR triage digest), which was unset — so the job skipped with "no repos configured (RENOVATE_REPOS)".

```
RENOVATE_REPOS: "swibrow/*,cloudsnacks/*,propagit-dev/*"
```

The `owner/*` glob expands to every non-fork, non-archived repo of that org or user.

## ⚠️ Ordering dependency
The `owner/*` glob only exists in goat **>= 0.13** (swibrow/goat#45). This deployment is pinned to `v0.12.3`, which would treat `swibrow/*` as a literal repo slug and 404. Merge order:
1. Merge swibrow/goat#45 → release cuts `0.13.0` → CI auto-bumps this repo's `image.tag`.
2. This PR can merge any time after the image is on `0.13.x`.

Merging this before the image bump leaves `renovate-digest` erroring until the bump lands.

## Test plan
- [ ] goat image on `>= v0.13.x`
- [ ] Next weekday 07:45 Europe/Zurich: `renovate-digest` posts a queue instead of the skip message (or stays silent if no open bot PRs)