### PR TITLE
feat(goat): request offline_access for kanidm refresh tokens

### DIFF
--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -54,10 +54,15 @@ sentinel:
 # this instance — not via requiredGroup, since kanidm only puts a "groups"
 # claim on the id_token (not the access_token GOAT validates) without an
 # explicit oauth2_rs_claim_map, so requiredGroup 401s every request.
+# offline_access makes kanidm mint a refresh token so the SPA renews the
+# short-lived access token silently instead of bouncing through login. Set
+# explicitly here so it applies before the chart default (>=0.14) rolls out.
+# Session length is the kanidm auth-expiry on app_access (24h).
 oidc:
   enabled: true
   issuer: https://idm.wibrow.dev/oauth2/openid/goat
   clientId: goat
+  scopes: "openid email profile groups offline_access"
 secrets:
   externalSecrets:
     enabled: true


### PR DESCRIPTION
## Summary

Stops the GOAT web SPA from bouncing through kanidm login every ~15 min. Sets `oidc.scopes` explicitly to add **`offline_access`**, so kanidm mints a refresh token and the SPA renews its access token silently.

- Set here (not just via chart default) so it applies on the pinned **0.13.1** chart — the chart-default change ships in a later goat release ([goat#47](https://github.com/swibrow/goat/pull/47)).
- `requiredGroup` intentionally left unset (kanidm only puts the `groups` claim on the id_token, not the access_token GOAT validates — see the existing comment in values).

## Live kanidm state (already applied on idm.wibrow.dev)

- scope-map: `goat` → `app_access` grants `openid email profile groups offline_access`
- `app_access` account policy enabled, `authsession_expiry: 86400` (24h session ceiling)

## Test plan

- [ ] ArgoCD syncs; goat api pod restarts with `OIDC_SCOPES` including `offline_access`
- [ ] `curl -s https://goat.wibrow.dev/v1/auth/config` lists `offline_access` in scopes
- [ ] Log in, leave a tab idle past access-token expiry, confirm no redirect and API calls keep working
- [ ] Events stream survives a token expiry without dropping