### PR TITLE
feat(garrison): open the full toolhive MCP catalog to raids, add a log archive

### DIFF
--- a/kubernetes/apps/pitower/ai/toolhive/toolhive-config/networkpolicy.yaml
+++ b/kubernetes/apps/pitower/ai/toolhive/toolhive-config/networkpolicy.yaml
@@ -127,14 +127,18 @@ spec:
         - protocol: TCP
           port: 4483
 ---
-# Garrison raid agents (runner sandboxes in ns garrison) may call a curated
-# subset of the mcp-tools backend proxies directly — per-repo selection and
-# tool allowlists are enforced garrison-side, this is the network floor.
-# Deliberately excluded: kubernetes/argocd/aws-api/home-assistant
-# (privileged identities). NetworkPolicies are additive, so this only widens
-# ingress for the listed proxies; the workload pods stay proxy-only. The
+# Garrison raid agents (runner sandboxes in ns garrison) may call the mcp-tools
+# backend proxies directly — per-repo selection and tool allowlists are enforced
+# garrison-side, this is the network floor. Every backend is now listed: the
+# privileged three are read-only at the identity (kubernetes = cluster-view RBAC,
+# argocd = MCP_READ_ONLY, aws-api = READ_OPERATIONS_ONLY), and the two that can
+# write — database-toolbox's execute_sql and home-assistant's actuators — are
+# held to read-only tool allowlists in the garrison catalog
+# (apps/pitower/garrison/garrison/values.yaml, mcp.catalog), enforced in the
+# runner by a PreToolUse deny hook. NetworkPolicies are additive, so this only
+# widens ingress for the listed proxies; the workload pods stay proxy-only. The
 # egress half lives in the garrison chart values
-# (networkPolicy.runnerExtraEgress).
+# (networkPolicy.runnerExtraEgress), which already covers every mcpserver proxy.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -151,6 +155,11 @@ spec:
           - context7
           - grafana
           - terraform
+          - kubernetes
+          - argocd
+          - aws-api
+          - database-toolbox
+          - home-assistant
   policyTypes:
     - Ingress
   ingress:

--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -34,6 +34,17 @@ herald:
 # version above is bumped past it, these keys are inert.
 warhorn:
   enabled: true
+# Post-mortem log source. Kubernetes drops a raid pod's logs when the pod goes,
+# so `garrison keep logs`, the wartable panel, and the emissary pod_logs tool
+# used to go blind on exactly the raids worth investigating. VictoriaLogs keeps
+# 14d (monitoring/victoria-logs), and the keep falls back to it whenever the
+# live pod read fails. Namespace defaults to runner.namespace (garrison), which
+# is where the sortie pods log from. The keep has no egress NetworkPolicy, so
+# nothing else is needed to reach the monitoring namespace.
+# NOTE: requires chart >= the release carrying logArchive — until the version
+# above is bumped past it, these keys are inert.
+logArchive:
+  url: http://victoria-logs.monitoring.svc.cluster.local:9428
 secrets:
   authEnabled: true
   # wartable is VPN-only (envoy-internal); /internal stays token-gated.
@@ -124,3 +135,67 @@ mcp:
     - name: terraform
       url: http://mcp-terraform-proxy.ai.svc.cluster.local:8080/mcp
       description: Terraform registry providers/modules docs
+    # The cluster-facing half of the catalog. These were held back originally
+    # because their backends carry privileged identities, but each is read-only
+    # at the identity itself, not merely by allowlist: kubernetes runs under the
+    # cluster-**view** ClusterRole, argocd sets MCP_READ_ONLY, aws-api sets
+    # READ_OPERATIONS_ONLY. That makes them safe to hand a raid agent debugging
+    # a live deployment, which is most of what raids on this fleet do.
+    - name: kubernetes
+      url: http://mcp-kubernetes-proxy.ai.svc.cluster.local:8080/mcp
+      description: Live cluster state — resources, pod logs, events (cluster-view RBAC, read-only)
+    - name: argocd
+      url: http://mcp-argocd-proxy.ai.svc.cluster.local:8080/mcp
+      description: ArgoCD applications, sync status, and history (MCP_READ_ONLY)
+    - name: aws-api
+      url: http://mcp-aws-api-proxy.ai.svc.cluster.local:8080/mcp
+      description: AWS API reads via the toolhive-aws-ro IRSA role (READ_OPERATIONS_ONLY)
+    # database-toolbox exposes a per-cluster `*_execute_sql` alongside its
+    # read tools, and home-assistant can actuate devices — neither backend is
+    # read-only on its own, so both are held to a listing/read allowlist here
+    # (enforced in the runner by the PreToolUse deny hook, not by the server).
+    # The toolbox exposes one pair of tools per cloudnative-pg cluster,
+    # `<cluster>_list_tables` and `<cluster>_execute_sql`, and it connects as
+    # each database's app user — so execute_sql is a live write vector on prod
+    # data. Only the schema-listing half is granted. A new cluster's entry has
+    # to be added here explicitly; that is the point.
+    - name: database-toolbox
+      url: http://mcp-database-toolbox-proxy.ai.svc.cluster.local:8080/mcp
+      description: Postgres schema inspection across the cloudnative-pg clusters (list_tables only)
+      tools:
+        - autobrr_list_tables
+        - backstage_list_tables
+        - firefly_list_tables
+        - forgejo_list_tables
+        - garrison_list_tables
+        - gatus_list_tables
+        - ghostfolio_list_tables
+        - house-hunter_list_tables
+        - litellm_list_tables
+        - mattermost_list_tables
+        - memini_list_tables
+        - miniflux_list_tables
+        - open-webui_list_tables
+        - paperless_list_tables
+        - propagit_list_tables
+        - rybbit_list_tables
+        - temporal_list_tables
+    # hass-mcp can actuate the house: entity_action, call_service_tool and
+    # restart_ha are omitted, everything granted below only reads state.
+    - name: home-assistant
+      url: http://mcp-home-assistant-proxy.ai.svc.cluster.local:8080/mcp
+      description: Home Assistant entity/automation state and history (read-only subset)
+      tools:
+        - get_version
+        - get_entity
+        - list_entities
+        - get_entities_by_area
+        - search_entities_tool
+        - domain_summary_tool
+        - system_overview
+        - list_automations
+        - get_error_log
+        - get_history
+        - get_history_range
+        - get_statistics
+        - get_statistics_range

--- a/kubernetes/apps/pitower/home-automation/frigate/kustomization.yaml
+++ b/kubernetes/apps/pitower/home-automation/frigate/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: home-automation
 resources:
+  - namespace.yaml
   - configmap.yaml
   - externalsecret.yaml
 components:

--- a/kubernetes/apps/pitower/home-automation/frigate/namespace.yaml
+++ b/kubernetes/apps/pitower/home-automation/frigate/namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: home-automation
+  annotations:
+    # frigate's /config/.jwt_secret is 0600 root-owned, so its kopiur mover runs
+    # as uid 0; kopiur requires this per-namespace opt-in for an elevated mover.
+    kopiur.home-operations.com/privileged-movers: "true"
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary

Two changes to the garrison deployment, both fallout from debugging why raids keep wiping.

### MCP catalog: 4 backends → all 9

Raid agents could reach `github`, `context7`, `grafana`, `terraform`. The three backends held back for "privileged identities" are all **read-only at the identity itself**, not merely by allowlist:

| Backend | Why it is safe |
|---|---|
| `kubernetes` | cluster-**view** ClusterRole |
| `argocd` | `MCP_READ_ONLY` |
| `aws-api` | `READ_OPERATIONS_ONLY` |

That makes them safe to hand an agent debugging a live deployment, which is most of what raids on this fleet do.

The two that genuinely write are held to read-only tool allowlists instead, enforced runner-side by the PreToolUse deny hook:

- **database-toolbox** → only the 17 `<cluster>_list_tables` tools. Its `<cluster>_execute_sql` twins connect as each database's app user, so they are a live write vector on prod data. A new cloudnative-pg cluster has to be added here by hand; that is deliberate.
- **home-assistant** → state and history reads only. `entity_action`, `call_service_tool` and `restart_ha` are left out.

Tool names were read off the live proxies via `tools/list`, not guessed — my first guesses were wrong and would have silently allowlisted nothing.

A raid pod runs every stage (decompose/spec/implement/verify) in one pod under `app.kubernetes.io/name: garrison-runner`, so the runner ingress covers the coordinator too and needs no separate entry.

### Log archive

Kubernetes drops a pod's logs with the pod, so garrison's recovery verbs went blind the moment a raid wiped, hibernated, or was reclaimed — exactly when the output matters. Points the keep at `victoria-logs` (14d retention) as a fallback. Namespace defaults to `runner.namespace` (`garrison`), which is where the sortie pods log from.

## Test plan

- [x] `yq` verifies all 9 catalog entries and all 9 netpol values parse and match the live service names
- [x] Every URL checked against the running services in ns `ai`; all are `streamable-http` on `/mcp` except grafana, which stays `/sse`
- [x] `database-toolbox` and `home-assistant` tool names pulled from the live proxies over MCP `tools/list`
- [x] Chart renders `KEEP_LOG_ARCHIVE_*` when `logArchive.url` is set and nothing when unset
- [x] Archive query verified against live VictoriaLogs — pulled raid_58's tail back in reading order
- [x] Keep has no egress NetworkPolicy, confirmed with `kubectl get netpol -n garrison`, so reaching monitoring needs no rule

## Notes for the reviewer

- **Catalog entries are available, not active.** The keep resolves a raid's servers from `project.mcpServers` — the project's *selections*. Right now `garrison` selects `[github, context7]`, `home-ops` selects `[context7, grafana, github, terraform]`, and `homb`/`blog`/`flickerd`/`goat` select nothing at all. Selections are validated against the catalog at write time, so a project cannot select `kubernetes` until this lands and syncs. Sequence: merge → ArgoCD sync → PATCH each project's `mcpServers`.
- `logArchive` needs the garrison chart release carrying the key; inert until the pinned version moves past it, same as the existing `mcp` and `warhorn` notes in this file.