### PR TITLE
feat(toolhive): add victorialogs MCP backend

### DIFF
--- a/kubernetes/apps/pitower/ai/toolhive/toolhive-config/kustomization.yaml
+++ b/kubernetes/apps/pitower/ai/toolhive/toolhive-config/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - externalsecret.yaml
   - mcpserver-kubernetes.yaml
   - mcpserver-grafana.yaml
+  - mcpserver-victorialogs.yaml
   - mcpserver-home-assistant.yaml
   - mcpserver-argocd.yaml
   - mcpserver-aws-api.yaml

--- a/kubernetes/apps/pitower/ai/toolhive/toolhive-config/mcpserver-victorialogs.yaml
+++ b/kubernetes/apps/pitower/ai/toolhive/toolhive-config/mcpserver-victorialogs.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/toolhive.stacklok.dev/mcpserver_v1beta1.json
+# VictoriaLogs MCP backend — read-only LogsQL against the 14d log store
+# (monitoring/victoria-logs), plus embedded VictoriaLogs docs search (no egress
+# needed; the docs ship in the binary). Unauthenticated, in-cluster only, ingress
+# locked to the two vMCP pods (networkpolicy.yaml); auth is enforced at the vMCP edge.
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: victorialogs
+spec:
+  image: ghcr.io/victoriametrics/mcp-victorialogs:v1.9.0
+  transport: streamable-http
+  proxyPort: 8080
+  mcpPort: 8081
+  groupRef:
+    name: mcp-tools
+  env:
+    - name: VL_INSTANCE_ENTRYPOINT
+      value: http://victoria-logs.monitoring.svc.cluster.local:9428
+    # Image default is stdio; MCP_SERVER_MODE=http serves the /mcp endpoint.
+    - name: MCP_SERVER_MODE
+      value: http
+    # Default is localhost:8081, which the proxy can't reach across the pod
+    # boundary — the bare colon form binds all interfaces.
+    - name: MCP_LISTEN_ADDR
+      value: ":8081"
+    - name: MCP_LOG_FORMAT
+      value: json
+  # krr: victorialogs/toolhive
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      memory: 256Mi

--- a/kubernetes/apps/pitower/ai/toolhive/toolhive-config/networkpolicy.yaml
+++ b/kubernetes/apps/pitower/ai/toolhive/toolhive-config/networkpolicy.yaml
@@ -32,6 +32,7 @@ spec:
           - terraform
           - context7
           - database-toolbox
+          - victorialogs
   policyTypes:
     - Ingress
   ingress:
@@ -72,6 +73,7 @@ spec:
           - terraform
           - context7
           - database-toolbox
+          - victorialogs
   policyTypes:
     - Ingress
   ingress:
@@ -92,6 +94,7 @@ spec:
                   - terraform
                   - context7
                   - database-toolbox
+                  - victorialogs
 ---
 # The anonymous vMCP (mcp-gateway-direct) has no auth of its own, so restrict its
 # ingress to the only legitimate callers: the Envoy proxy pods (which terminate the


### PR DESCRIPTION
Adds [mcp-victorialogs](https://github.com/VictoriaMetrics/mcp-victorialogs) as a ToolHive backend in the `mcp-tools` group, so both vMCP tiers (OAuth `mcp.wibrow.dev` and the anonymous direct gateway) expose it.

## What

- `mcpserver-victorialogs.yaml` — `ghcr.io/victoriametrics/mcp-victorialogs:v1.9.0`, `streamable-http` on `mcpPort: 8081` behind the usual proxy on `8080`, pointed at `http://victoria-logs.monitoring.svc.cluster.local:9428`.
- `kustomization.yaml` — registers the resource.
- `networkpolicy.yaml` — adds `victorialogs` to the proxy-from-vMCP and workload-from-proxy selector lists.

## Notes on the config

- The image defaults to `stdio` and binds `localhost:8081`, so `MCP_SERVER_MODE=http` plus a bare-colon `MCP_LISTEN_ADDR` are both load-bearing — without the latter the proxy can't reach the workload across the pod boundary.
- No secret. The `victoria-logs-single` deployment runs unauthenticated in-cluster, so `VL_INSTANCE_BEARER_TOKEN` is unset.
- No `permissionProfile`. Traffic is in-cluster only and the VictoriaLogs docs are embedded in the binary, so there is no egress requirement (same shape as the grafana backend).

## Verification

- `kustomize build --enable-helm` renders clean; `kubectl apply --dry-run=server` accepts the MCPServer and the NetworkPolicies against the live 0.40.1 CRDs.
- Ran the image locally with exactly the env set here (against the public playground): logs `Server is listening addr=":8081"`, `/health/readiness` returns 200, and a streamable-HTTP `initialize` + `tools/list` on `/mcp` succeeds.
- 13 tools exposed, all read-only: `query`, `stats_query`, `stats_query_range`, `hits`, `facets`, `streams`, `stream_ids`, `stream_field_names`, `stream_field_values`, `field_names`, `field_values`, `flags`, `documentation`.

## Follow-up (not in this PR)

Not added to the garrison catalog (`apps/pitower/garrison/garrison/values.yaml` `mcp.catalog`) or the `mcp-backend-proxy-from-garrison-runners` ingress list, so that policy's "every backend is now listed" comment is momentarily stale. It is fully read-only and log querying is squarely what raid debugging needs, so it is a natural next step — the runner egress rule is already generic over any `mcpserver` pod in `ai`, leaving just the catalog entry plus the ingress selector.