### PR TITLE
feat(dev-desktop): stream an Arch/Hyprland desktop from the AMD nodes

### DIFF
--- a/kubernetes/apps/pitower/dev/dev-desktop/kustomization.yaml
+++ b/kubernetes/apps/pitower/dev/dev-desktop/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dev
+resources:
+  - sandbox.yaml

--- a/kubernetes/apps/pitower/dev/dev-desktop/sandbox.yaml
+++ b/kubernetes/apps/pitower/dev/dev-desktop/sandbox.yaml
@@ -1,0 +1,117 @@
+---
+# Arch/Hyprland desktop streamed to Moonlight clients over Sunshine.
+# Suspend when unused with `operatingMode: Suspended` (the home PVC is retained).
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: dev-desktop
+spec:
+  operatingMode: Running
+  # Sunshine needs raw TCP/UDP, so the LoadBalancer Service below replaces the
+  # controller's auto headless Service.
+  service: false
+  shutdownPolicy: Retain
+  volumeClaimTemplates:
+    - metadata:
+        name: home
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: openebs-hostpath
+        resources:
+          requests:
+            storage: 100Gi
+  podTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dev-desktop
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              # The AMD Renoir APUs are the only nodes with a usable render node
+              # and a VCN encoder. worker-07's only VGA device is QEMU virtual.
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/amd-gpu
+                    operator: In
+                    values: ["true"]
+                  # worker-01/02/03 are control-plane nodes that already run hot;
+                  # worker-01 has the least headroom (~12.8Gi allocatable vs ~28Gi),
+                  # and starving it previously jammed the apiserver.
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: ["worker-01"]
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+        - name: dev-desktop
+          image: ghcr.io/cloudsnacks/dev-desktop:1.0.0
+          env:
+            - name: TZ
+              value: Europe/Zurich
+            - name: DOTFILES_REPO
+              value: https://github.com/swibrow/dotfiles.git
+          ports:
+            - { name: https, containerPort: 47984, protocol: TCP }
+            - { name: http, containerPort: 47989, protocol: TCP }
+            - { name: web, containerPort: 47990, protocol: TCP }
+            - { name: rtsp, containerPort: 48010, protocol: TCP }
+            - { name: video, containerPort: 47998, protocol: UDP }
+            - { name: control, containerPort: 47999, protocol: UDP }
+            - { name: audio, containerPort: 48000, protocol: UDP }
+            - { name: mic, containerPort: 48002, protocol: UDP }
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              # Capped well under node capacity so a busy desktop cannot starve
+              # the control-plane services sharing this node.
+              cpu: "6"
+              memory: 10Gi
+          volumeMounts:
+            - name: home
+              mountPath: /home/dev
+            - name: dri
+              mountPath: /dev/dri
+            - name: uinput
+              mountPath: /dev/uinput
+      volumes:
+        # Hyprland cannot start without a render node even though it is headless:
+        # aquamarine only builds a GBM allocator from a backend reporting
+        # drmFD() >= 0, and the headless backend returns -1. renderD128 is 0666
+        # on these nodes, so no supplementalGroups are needed.
+        - name: dri
+          hostPath:
+            path: /dev/dri
+            type: Directory
+        # Requires siderolabs/uinput in the node schematic; without it Moonlight
+        # gets video and audio but no mouse or keyboard.
+        - name: uinput
+          hostPath:
+            path: /dev/uinput
+            type: CharDevice
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dev-desktop
+  annotations:
+    lbipam.cilium.io/ips: "10.20.10.231"
+spec:
+  type: LoadBalancer
+  # Preserve client IPs so Sunshine pairs against the real client address.
+  externalTrafficPolicy: Local
+  selector:
+    app.kubernetes.io/name: dev-desktop
+  ports:
+    - { name: https, port: 47984, targetPort: https, protocol: TCP }
+    - { name: http, port: 47989, targetPort: http, protocol: TCP }
+    - { name: web, port: 47990, targetPort: web, protocol: TCP }
+    - { name: rtsp, port: 48010, targetPort: rtsp, protocol: TCP }
+    - { name: video, port: 47998, targetPort: video, protocol: UDP }
+    - { name: control, port: 47999, targetPort: control, protocol: UDP }
+    - { name: audio, port: 48000, targetPort: audio, protocol: UDP }
+    - { name: mic, port: 48002, targetPort: mic, protocol: UDP }

--- a/talos/pitower/control-plane/02-uinput.yaml
+++ b/talos/pitower/control-plane/02-uinput.yaml
@@ -1,0 +1,18 @@
+machine:
+  # Virtual input devices for Sunshine (dev/dev-desktop). Without /dev/uinput a
+  # Moonlight client gets video and audio but cannot move the mouse or type.
+  #
+  # uinput is neither built into the stock Talos kernel nor shipped as a module
+  # (kernel/drivers/input/ is absent from /lib/modules), so loading it depends on
+  # siderolabs/uinput being in the schematic — see ../extensions/amd.yaml. That
+  # makes this a control-plane-only patch: worker-01/02/03 are the AMD nodes and
+  # the only ones whose schematic carries the extension.
+  kernel:
+    modules:
+      - name: uinput
+  udev:
+    rules:
+      # The desktop container runs rootless (uid 1001) and the host GIDs do not
+      # line up with the image's, so widen the mode rather than match a group.
+      # /dev/dri/renderD128 is already 0666 by default; uinput defaults to 0600.
+      - SUBSYSTEM=="misc", KERNEL=="uinput", MODE="0666"

--- a/talos/pitower/extensions/amd.yaml
+++ b/talos/pitower/extensions/amd.yaml
@@ -1,4 +1,4 @@
-# 86e7fd87fc2c25ce2adb947bbf084f78d473e206487a2eb7df5fc157539bc999
+# 1be3f9d3a9e719976e7488507ecbd05f371c5325562bd95d707e4b3718c24589
 # curl -X POST --data-binary @amd.yaml https://factory.talos.dev/schematics
 customization:
   systemExtensions:
@@ -7,3 +7,7 @@ customization:
       - siderolabs/amd-ucode
       - siderolabs/amdgpu-firmware
       - siderolabs/amdgpu
+      # Virtual input devices for Sunshine: Moonlight clients have no input
+      # without /dev/uinput. Not in the stock Talos kernel (neither builtin
+      # nor a shipped module), so it has to come from this extension.
+      - siderolabs/uinput


### PR DESCRIPTION
Runs `ghcr.io/cloudsnacks/dev-desktop` as a Sandbox in `dev`, streamed to Moonlight clients over Sunshine on `10.20.10.231`. Pairs with cloudsnacks/containers#1.

## Why the AMD nodes

worker-01/02/03 carry AMD Renoir APUs (`0x1002:0x164C`) with a VCN 2.0 encoder (`vcn_enc0`/`vcn_enc1`), so Sunshine gets VAAPI hardware encode. They are the only viable targets:

- The Intel workers have a render node and an existing device plugin, but only 4 CPU / ~8 GB.
- worker-07 is the biggest box but its only VGA device is `1234` (QEMU virtual), so no render node and no encoder.

worker-01 is excluded via `nodeAffinity`: it has ~12.8 Gi allocatable versus ~28 Gi on worker-02/03, and per `control-plane/01-cluster.yaml` starving these control planes has previously jammed the apiserver. Limits are capped at 6 CPU / 10 Gi for the same reason.

## Host devices

**`/dev/dri`** - Hyprland cannot start without a render node *even headless*. Aquamarine only builds a GBM allocator from a backend reporting `drmFD() >= 0`, and `CHeadlessBackend::drmFD()` returns `-1`. `renderD128` is already `0666` on these nodes, so no `supplementalGroups` are required.

**`/dev/uinput`** - without it Moonlight gets video and audio but no mouse or keyboard.

## The uinput change needs a node upgrade

`uinput` is neither built into the stock Talos kernel nor shipped as a module (`kernel/drivers/input/` is absent from `/lib/modules`), so `machine.kernel.modules` alone would fail. `siderolabs/uinput` therefore joins the AMD schematic, which changes its ID:

```
86e7fd87... -> 1be3f9d3...
```

`control-plane/02-uinput.yaml` then loads the module and relaxes the node to `0666` (it defaults to `0600` and the container is rootless). The patch is control-plane-scoped because only those nodes carry the extension; `topf render` confirms it appears on worker-01/02/03 and on none of the workers.

**This requires a Talos upgrade and reboot of worker-01/02/03.** Until that lands the pod stays pending on the missing `CharDevice`, which is deliberate: it fails loudly rather than silently streaming an uncontrollable desktop.

## Validation

`kubectl kustomize` builds, and `kubectl apply --server-side --dry-run=server` against pitower accepts both resources (including the mixed TCP/UDP LoadBalancer). `topf render` succeeds and scopes the patch correctly. Nothing has been applied to the cluster.