### PR TITLE
feat(goat): let GOAT reach the mcp-tools aggregate and clone repos

### DIFF
--- a/kubernetes/apps/pitower/ai/toolhive/toolhive-config/networkpolicy.yaml
+++ b/kubernetes/apps/pitower/ai/toolhive/toolhive-config/networkpolicy.yaml
@@ -99,9 +99,10 @@ spec:
 # The anonymous vMCP (mcp-gateway-direct) has no auth of its own, so restrict its
 # ingress to the only legitimate callers: the Envoy proxy pods (which terminate the
 # api-key external route and the no-auth internal route — auth/exposure is decided
-# there) and the in-cluster Hermes agent. Other in-cluster pods must use the OAuth
-# vMCP at mcp.wibrow.dev. vMCP listens on 4483. The OAuth vMCP (mcp-gateway) is left
-# unselected (open) because it enforces OAuth itself.
+# there) and the in-cluster agents that cannot run a browser OAuth flow (Hermes,
+# GOAT). Other in-cluster pods must use the OAuth vMCP at mcp.wibrow.dev. vMCP
+# listens on 4483. The OAuth vMCP (mcp-gateway) is left unselected (open) because it
+# enforces OAuth itself.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -126,6 +127,16 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: hermes
+        # GOAT's agent runtime (ns goat) — the api service runs every persona,
+        # which reach the whole mcp-tools group through this aggregate
+        # (CLUSTER_MCP_URL in the goat values). goat-hooks is not selected: it
+        # only receives webhooks and runs no agent.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: goat
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: goat-api
       ports:
         - protocol: TCP
           port: 4483

--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -40,6 +40,17 @@ api:
     # Renovate concierge (weekday morning digest of bot PRs). owner/* expands
     # to every repo of that org or user (goat >= 0.13).
     RENOVATE_REPOS: "swibrow/*,cloudsnacks/*,propagit-dev/*"
+    # The ToolHive vMCP aggregate (ns ai) — one endpoint fronting kubernetes,
+    # argocd, grafana, victorialogs, github, terraform, aws, database-toolbox
+    # and home-assistant. The -direct service is the anonymous tier meant for
+    # in-cluster agents; ingress is granted to goat-api by the toolhive-config
+    # networkpolicy. Unset = the cluster plugin loads without its server, so
+    # personas still work, they just cannot reach the cluster.
+    CLUSTER_MCP_URL: http://vmcp-mcp-gateway-direct.ai:4483
+    # Repos an agent may clone on demand into /data/workspace/checkouts via
+    # mcp__sre__checkout_repo. This allowlist is the whole gate — anything not
+    # matched here is refused.
+    REPO_CHECKOUT_ALLOWLIST: "swibrow/*,DND-IT/*,tx-pts-dai/*,20minuten/*"
 # Dev-session pods (Claude Code in the goat namespace) — needs the
 # ghcr.io/swibrow/claude-code image and the egress NetworkPolicy below.
 devSessions:


### PR DESCRIPTION
## Summary

GOAT runs every persona in-process in `goat-api` and had no path to the MCP backends, so it operated the cluster blind. A live alert investigation gave up at *"the home-ops repo is not present in the workspace"* and returned `insufficient` instead of a root cause.

- **`mcp-gateway-direct-ingress`**: add ns `goat` / pod `goat-api` alongside the Envoy proxies and Hermes. It is the same case Hermes is — a server-side agent that cannot run a browser OAuth flow — so the anonymous vMCP is the tier it belongs on. `goat-hooks` is deliberately not selected: it receives webhooks and runs no agent.
- **`CLUSTER_MCP_URL`**: points GOAT's new `cluster` plugin at `vmcp-mcp-gateway-direct.ai:4483`. That plugin exposes `find_tool`/`call_tool` only, so the whole mcp-tools group costs two tool definitions of context rather than the backends' full catalogue.
- **`REPO_CHECKOUT_ALLOWLIST`**: the whole gate on what an agent may clone into `/data/workspace/checkouts` via `mcp__sre__checkout_repo`. Anything unmatched is refused.

Pairs with swibrow/goat#54. Merging this first is harmless — the env vars do nothing until a goat release carrying the `cluster` plugin (>= 0.18) rolls out.

## Test plan

- [x] `kubectl apply --dry-run=server` on the NetworkPolicy file
- [x] Confirmed the current block is real: probing `vmcp-mcp-gateway-direct.ai:4483` from the `goat-api` pod times out today
- [x] Gateway itself verified over a port-forward — `initialize` + `tools/list` return `find_tool`/`call_tool`, and `find_tool` returns real backend schemas
- [ ] After merge: re-probe from `goat-api` and expect a JSON-RPC response instead of a timeout
- [ ] After the goat release: run an alert through the pipeline and confirm the investigator reaches a code-level verdict

## Notes

`call_tool` is a generic dispatcher, so it cannot be constrained by tool name on the GOAT side. `database-toolbox` `execute_sql` and the Home Assistant actuators can write, and GOAT has no equivalent of the garrison runner's PreToolUse deny hook — its read-only posture is prompt-level for now.