### PR TITLE
fix(proxmox,cnpg): worker-07 disk latency and database cluster pinning

### DIFF
--- a/ansible/roles/proxmox/defaults/main.yaml
+++ b/ansible/roles/proxmox/defaults/main.yaml
@@ -12,6 +12,29 @@ proxmox_acme_email: sam.wibrow.wa@gmail.com
 proxmox_acme_plugin: cloudflare
 proxmox_acme_directory: https://acme-v02.api.letsencrypt.org/directory
 
+# ZFS dataset properties applied to guest zvols. rpool is 8x 600GB 10K SAS
+# spinning (4 mirror vdevs, no SLOG), so sync writes cost a seek. Measured on
+# vm-200 (worker-07): 21-33 MB/s of ZIL traffic and 27-103 zil_commit/s were
+# driving 90-127 MB/s of physical spindle writes against a guest writing only
+# 12-16 MB/s. sync=disabled dropped that to 6.3 MB/s and took guest write
+# latency 11.26ms -> 2.67ms, because WAL rewrites of the same blocks now
+# coalesce in ARC within the txg instead of each being forced out.
+#
+# The trade: the guest loses up to one txg (~5s) of acknowledged writes on host
+# power loss. Accepted here - the node's local disk holds TSDBs (prometheus,
+# victoria-metrics, victoria-logs, tempo) which just re-scrape, plus media that
+# kopiur backs up. The ceph mons that used to make this unsafe now live on
+# worker-01/02/03. Postgres is the one workload this is wrong for.
+#
+# NOT expressible in terraform: Proxmox has no per-VM setting for it, it is a
+# host-side ZFS dataset property. Also note a zvol recreated by terraform comes
+# back as sync=standard, silently restoring the 11ms - rerun this playbook after
+# any VM disk recreate.
+proxmox_zfs_volume_properties:
+  - dataset: rpool/data/vm-200-disk-1
+    properties:
+      sync: disabled
+
 proxmox_network_iface: nic1
 proxmox_network_vlan: 20
 proxmox_network_bridge: vmbr0

--- a/ansible/roles/proxmox/tasks/main.yaml
+++ b/ansible/roles/proxmox/tasks/main.yaml
@@ -24,6 +24,15 @@
     update_cache: true
   when: pve_enterprise_repo.changed or pve_no_subscription_repo.changed
 
+- name: Set ZFS properties on guest zvols
+  community.general.zfs:
+    name: "{{ item.dataset }}"
+    state: present
+    extra_zfs_properties: "{{ item.properties }}"
+  loop: "{{ proxmox_zfs_volume_properties }}"
+  loop_control:
+    label: "{{ item.dataset }} {{ item.properties }}"
+
 - name: Configure Let's Encrypt for the web UI
   ansible.builtin.include_tasks: acme.yaml
   when: proxmox_acme_enabled

--- a/kubernetes/apps/pitower/database/clusters/kustomization.yaml
+++ b/kubernetes/apps/pitower/database/clusters/kustomization.yaml
@@ -6,3 +6,9 @@ namespace: database
 resources:
   - immich.yaml
   - phoenix.yaml
+patches:
+  - path: patches/affinity.yaml
+    target:
+      group: postgresql.cnpg.io
+      version: v1
+      kind: Cluster

--- a/kubernetes/apps/pitower/database/clusters/patches/affinity.yaml
+++ b/kubernetes/apps/pitower/database/clusters/patches/affinity.yaml
@@ -1,0 +1,24 @@
+---
+# Pin all CNPG clusters to worker-05 / worker-06 (OpenEBS hostpath data is node-local).
+# Required pod anti-affinity ensures the two instances never share a node.
+#
+# Duplicated from cloudnative-pg/cluster/patches/affinity.yaml rather than shared:
+# kustomize load restrictions refuse a patch path outside the kustomization root,
+# and these Clusters live in their own overlay. Keep the two files in step.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: not-used
+spec:
+  affinity:
+    podAntiAffinityType: required
+    topologyKey: kubernetes.io/hostname
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                  - worker-05
+                  - worker-06

--- a/terraform/proxmox/vm_worker_07.tf
+++ b/terraform/proxmox/vm_worker_07.tf
@@ -52,8 +52,17 @@ resource "proxmox_virtual_environment_vm" "talos_worker" {
     # 14.65ms avg write latency here vs 0.4-0.6ms on the NVMe control planes, at
     # the same ~350 write IOPS. writeback lets the host absorb writes in its ARC
     # (128GiB, on 755GiB of RAM) instead. The power-loss window this opens is
-    # covered by the UPS + dual PSU; without those this would risk the rook-ceph
-    # mon's rocksdb, which is resident on this node.
+    # covered by the UPS + dual PSU.
+    #
+    # writeback alone only got this to ~11ms; the rest of the fix is sync=disabled
+    # on the backing zvol, which is NOT settable from here (Proxmox exposes no
+    # per-VM knob - it is a host-side ZFS dataset property). It lives in the
+    # ansible proxmox role as proxmox_zfs_volume_properties, and that is where the
+    # measurements and the durability trade-off are written up.
+    #
+    # If this disk is ever recreated, the new zvol defaults back to sync=standard
+    # and write latency silently returns to ~11ms. Rerun the ansible proxmox role
+    # after any recreate.
     cache = "writeback"
   }
 


### PR DESCRIPTION
## Summary

Two fixes from investigating worker-07's disk I/O, which was the cluster's clear outlier: 11.26ms avg write latency, 39.5% utilization, queue depth 6.45, and 6% PSI full I/O stall (10x every other node).

**`fix(proxmox)`** — root cause was sync writes on a spinning pool. rpool is 8x 600GB 10K SAS (4 mirror vdevs, no SLOG), and 21-33 MB/s of ZIL traffic plus 27-103 `zil_commit`/s were driving 90-127 MB/s of physical spindle writes against a guest writing only 12-16 MB/s.

`sync=disabled` on the zvol, measured before/after:

| | before | after |
|---|---|---|
| guest write latency | 11.26 ms | **2.67 ms** |
| queue depth | 6.45 | 0.93 |
| utilization | 39.5% | 12.6% |
| PSI io full | 6.0% | 1.9% |
| host ZIL | 21-33 MB/s | **0** |
| host spindle writes | 90-127 MB/s | **6.3 MB/s** |

Spindle writes fell ~15x, more than removing the ZIL double-write alone accounts for: without sync forcing each one out, TSDB WAL rewrites of the same blocks coalesce in ARC inside the txg and only the final version lands. worker-07 now sits in the same range as worker-05/06 (2.2-3.8ms).

This also makes a SLOG pointless — with no ZIL traffic a log vdev has nothing to absorb — so the two free front bays stay free.

**`fix(cnpg)`** — `database/clusters` had no `patches` block, so `immich` and `phoenix` free-scheduled while the 19 clusters in `cloudnative-pg` were pinned. All four instances had drifted off the storage nodes, two onto control planes.

## Trade-off accepted

worker-07 can lose up to one txg (~5s) of acknowledged writes on host power loss. Acceptable here: its local disk holds TSDBs that re-scrape, plus media kopiur backs up, and the rook-ceph mons that previously made this unsafe moved to the control planes in b1c668ce. Reverts with `zfs set sync=standard rpool/data/vm-200-disk-1`.

Postgres is the one workload this is wrong for, which the second commit addresses.

## ⚠️ Merging arms a landmine — read before merge

The CNPG commit pins **scheduling only and moves no data**. All four instances have node-locked `openebs-hostpath` PVCs:

| Instance | Current node |
|---|---|
| `immich-1` | worker-07 |
| `immich-2` | worker-03 (control plane) |
| `phoenix-1` | worker-03 (control plane) |
| `phoenix-2` | worker-02 (control plane) |

`nodeAffinity` is `IgnoredDuringExecution`, so running pods stay put and nothing breaks on merge. But each becomes unschedulable **on its next restart** — the PVC forces the old node, the affinity forbids it — and goes Pending permanently.

Per cluster, one instance at a time, primary last:

1. Confirm cluster health and which instance is primary.
2. Delete a replica's pod **and** PVC; CNPG rebuilds it from the primary via `pg_basebackup` onto a pinned node.
3. Wait for both instances streaming.
4. For the last instance, promote the healthy replica first, then rebuild the old primary.

Hold this PR until you can watch that, or merge and migrate immediately after.

## Test plan

- [x] `sync=disabled` applied and measured on the live host (numbers above)
- [x] ansible task dry-runs `ok, changed=0` against proxmox-01 — idempotent against applied state
- [x] `ansible-playbook --syntax-check` passes
- [x] `terraform fmt -check` clean; pre-commit fmt/validate/tflint passed
- [x] `kustomize build` renders the pin onto both `immich` and `phoenix`
- [x] patch spec verified byte-identical to `cloudnative-pg/cluster/patches/affinity.yaml`
- [x] terraform-proxmox plan is a no-op (comment-only change) — confirm in CI
- [ ] CNPG instance migration onto worker-05/06 (manual, post-merge)

## Notes

- The ansible change is not auto-applied; run `just deploy-proxmox-01`. No drift, since the property is already set live.
- Pre-existing and untouched: the `fail2ban` role fails under `--check` on proxmox-01 because check mode can't install the package first, blocking a full-playbook dry-run.