### PR TITLE
chore(arc): garrison runner image 2.336.0-3 and a bigger, warm runner pool

### DIFF
--- a/kubernetes/apps/pitower/arc/runners/kustomization.yaml
+++ b/kubernetes/apps/pitower/arc/runners/kustomization.yaml
@@ -140,7 +140,7 @@ helmCharts:
           serviceAccountName: garrison-runners
           containers:
             - name: runner
-              image: ghcr.io/cloudsnacks/actions-runner:2.336.0-1
+              image: ghcr.io/cloudsnacks/actions-runner:2.336.0-2
               command: ["/home/runner/run.sh"]
               resources:
                 requests:

--- a/kubernetes/apps/pitower/arc/runners/kustomization.yaml
+++ b/kubernetes/apps/pitower/arc/runners/kustomization.yaml
@@ -135,12 +135,20 @@ helmCharts:
     valuesInline:
       githubConfigUrl: https://github.com/swibrow/garrison
       runnerScaleSetName: garrison
+      # garrison's ci workflow fans out further than the shared default of two
+      # runners can absorb: on a main push it wants the five gates plus a keep
+      # and a runner image build at once. On run 30489535961 that queued for 56
+      # aggregate minutes against 24 minutes of actual work — build (keep) alone
+      # waited 22m54 for a slot. minRunners keeps one warm, which is what takes
+      # the ~10 minute ARC cold start off the front of every run.
+      minRunners: 1
+      maxRunners: 6
       template:
         spec:
           serviceAccountName: garrison-runners
           containers:
             - name: runner
-              image: ghcr.io/cloudsnacks/actions-runner:2.336.0-2
+              image: ghcr.io/cloudsnacks/actions-runner:2.336.0-3
               command: ["/home/runner/run.sh"]
               resources:
                 requests:


### PR DESCRIPTION
## Summary

- Bumps the garrison ARC runner scale set to `ghcr.io/cloudsnacks/actions-runner:2.336.0-3`. That revision adds headless Chromium's system libraries and font fallbacks (cloudsnacks/containers#4) so garrison's `wartable-ui` Playwright job runs `playwright install chromium` without root escalation (`--with-deps` was failing with `su: Authentication failure`), plus a mise-managed CLI toolchain — `gh`, `yq`, `hadolint`, `shellcheck` (cloudsnacks/containers#5) — so workflows stop curling their own copies into `RUNNER_TEMP`.
- Raises the garrison pool to `minRunners: 1`, `maxRunners: 6`. It inherits the shared `0/2` default today, which is the real reason garrison CI is slow: on run 30489535961 the workflow spent **56 aggregate minutes queued against 24 minutes of actual work**, with `build (keep)` waiting 22m54 for a slot and `gates` 12m08. A PR run the same evening had `gates` queued 23 minutes behind two `build-image` jobs that did nothing at all.
- `minRunners: 1` is the half that matters most — it keeps one runner warm so the ARC cold start stops landing on the front of every run. Cost is one idle runner pod (1 CPU / 4Gi requested) on the compute node.
- Manual bump: renovate deliberately doesn't track the `-N` revision suffix on this image.

## Ordering

cloudsnacks/containers#5 must merge and publish `2.336.0-3` before this lands, or the scale set rolls to a tag that doesn't exist. swibrow/garrison's CI rework depends on this in turn — it assumes `gh`/`yq` on the runner and the larger pool.

## Test plan

- [ ] ArgoCD syncs and the garrison scale set pods roll to 2.336.0-3
- [ ] `kubectl -n arc-runners get autoscalingrunnerset garrison` shows 1/6 and one warm pod
- [ ] Re-run `wartable-ui` on swibrow/garrison — green on the garrison runner