### PR TITLE
feat(garrison): sync the Claude token into the keep pod

### DIFF
--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -55,6 +55,11 @@ secrets:
     store: infisical
     basePath: /garrison
     githubApp: true
+    # /garrison/CLAUDE_CODE_OAUTH_TOKEN into garrison-keep-env: the keep pod
+    # runs Claude itself for the Guild Officer (the hosted Guild Chat replier,
+    # keep >= 0.48.0) and the quest-enrichment agent. Without it the officer
+    # parks at degraded with "Not logged in · Please run /login".
+    keepEnv: true
     # OTLP collector endpoint for runner sortie pods and the keep itself —
     # synced by the chart's own garrison-runner-env/garrison-keep-env
     # ExternalSecrets (requires chart >= 0.25.0). Replaces the standalone


### PR DESCRIPTION
## Why

Guild Chat stopped replying. The keep reports both repliers down:

```json
{ "runtime": "pi", "state": "stopped",
  "officer": { "state": "degraded",
    "error": "Claude Code returned an error result: Not logged in · Please run /login" } }
```

The Guild Officer (the hosted Guild Chat replier, garrison >= 0.48.0) runs Claude
*inside the keep pod*. The chart mounts `garrison-keep-env` via `envFrom` expecting
`CLAUDE_CODE_OAUTH_TOKEN`, but gates that key behind `secrets.externalSecrets.keepEnv`,
which defaults to `false` and was never set here — so the secret only ever held
`OTEL_EXPORTER_OTLP_ENDPOINT`:

```
$ kubectl get secret garrison-keep-env -n garrison -o jsonpath='{.data}' | jq -r 'keys[]'
OTEL_EXPORTER_OTLP_ENDPOINT
```

Every officer turn threw on the first captain message and parked the status at
`degraded` (`officer turn failed` in the keep logs). The quest-enrichment agent
(`agentEnrich: true`) uses the same credential and is broken for the same reason.

## What

Set `secrets.externalSecrets.keepEnv: true`. It syncs the same
`/garrison/CLAUDE_CODE_OAUTH_TOKEN` that `garrison-runner-env` already pulls, so no
new Infisical entry is needed.

## Verify after sync

```sh
kubectl get secret garrison-keep-env -n garrison -o jsonpath='{.data}' | jq -r 'keys[]'
# expect CLAUDE_CODE_OAUTH_TOKEN alongside OTEL_EXPORTER_OTLP_ENDPOINT
curl -sH "authorization: Bearer $GARRISON_KEEP_TOKEN" "$GARRISON_KEEP_URL/api/v1/guild-leader" | jq .officer.state
# expect idle/working, not degraded
```

The keep pods need a restart to pick up the new env.