### PR TITLE
feat(garrison): give raid runners memini credentials and egress

### DIFF
--- a/kubernetes/apps/pitower/garrison/garrison/values.yaml
+++ b/kubernetes/apps/pitower/garrison/garrison/values.yaml
@@ -67,6 +67,11 @@ secrets:
     # the chart's own ExternalSecrets for ownership of the same Secret.
     runnerOtel: true
     keepOtel: true
+    # /garrison/MEMINI_API_KEY into garrison-runner-env: cross-raid memory.
+    # A raid only uses it when its repo commits a memory.url to
+    # .garrison/config.yaml — the key alone is inert.
+    runnerProviderKeys:
+      - MEMINI_API_KEY
 persistence:
   size: 5Gi
 networkPolicy:
@@ -86,6 +91,20 @@ networkPolicy:
       ports:
         - protocol: TCP
           port: 8080
+    # memini (ai/memini) is only published on envoy-internal, so
+    # memini-api.wibrow.dev resolves to 10.20.10.238 — inside the blocked
+    # 10.0.0.0/8 range. Allowing the gateway pods on 443 also reaches every
+    # other internal vhost behind them; NetworkPolicy cannot filter by SNI.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking
+          podSelector:
+            matchLabels:
+              gateway.networking.k8s.io/gateway-name: envoy-internal
+      ports:
+        - protocol: TCP
+          port: 443
 httpRoute:
   enabled: true
   hostname: garrison.wibrow.dev


### PR DESCRIPTION
Enables cross-raid memory (memini) for hosted raids on pitower.

- `runnerProviderKeys: [MEMINI_API_KEY]` syncs `/garrison/MEMINI_API_KEY` (added to Infisical prod) into `garrison-runner-env`, so sortie pods get the key.
- `runnerExtraEgress` allowance to the `envoy-internal` gateway pods on 443. memini is published only on that gateway, so `memini-api.wibrow.dev` resolves to `10.20.10.238`, inside the `10.0.0.0/8` range the runner egress fence blocks.

Trade-off worth naming: NetworkPolicy cannot filter by SNI, so this allowance also lets raid agents reach the other internal vhosts behind `envoy-internal`. The tighter alternative (in-cluster `http://memini.ai.svc.cluster.local:8080` + pod-scoped rule) needs a `GARRISON_MEMORY_URL` override in garrison core first, since `.garrison/config.yaml` is shared with local CLI use.

No chart change needed — both knobs already exist in the chart. Verified by rendering `deploy/charts/garrison` against these values: the `MEMINI_API_KEY` entry appears in the `garrison-runner-env` ExternalSecret and the new egress rule in `garrison-runner-egress`.

A raid only uses the key once its repo commits `memory.url` to `.garrison/config.yaml`; until then both changes are inert.

https://claude.ai/code/session_01BPhLz5Qt3XHVyv4JoWUnW6