### PR TITLE
feat(goat): enable the MCP OAuth proxy via kanidm client goat-mcp

### DIFF
--- a/kubernetes/apps/pitower/goat/goat/values.yaml
+++ b/kubernetes/apps/pitower/goat/goat/values.yaml
@@ -75,6 +75,13 @@ oidc:
   issuer: https://idm.wibrow.dev/oauth2/openid/goat
   clientId: goat
   scopes: "openid email profile groups offline_access"
+  # MCP OAuth proxy (goat >= 0.22): /mcp advertises goat as its own OAuth
+  # server and proxies login through this kanidm public client (kanidm has no
+  # dynamic client registration). Redirect URL registered in kanidm:
+  # https://goat.wibrow.dev/oauth/callback. Access gated by the app_access
+  # scope map, same as the SPA client. The chart derives PUBLIC_BASE_URL from
+  # httpRoute.hostname when this is set.
+  mcpClientId: goat-mcp
 secrets:
   externalSecrets:
     enabled: true

--- a/talos/pitower/addons/cni/values.yaml
+++ b/talos/pitower/addons/cni/values.yaml
@@ -63,14 +63,6 @@ hubble:
   ui:
     enabled: true
     rollOutPods: true
-    ingress:
-      enabled: true
-      className: internal
-      hosts:
-        - "hubble.wibrow.dev"
-      tls:
-        - hosts:
-            - "hubble.wibrow.dev"
 ipam:
   mode: kubernetes
 ipv4NativeRoutingCIDR: 10.244.0.0/16


### PR DESCRIPTION
## Summary
- Sets `oidc.mcpClientId: goat-mcp` on the goat release: goat's `/mcp` endpoint fronts kanidm as an OAuth authorization server (local dynamic client registration, authorize/token proxied upstream), so MCP clients log in through kanidm instead of pasting the static token.
- Kanidm side is already done: public client `goat-mcp`, strict redirect `https://goat.wibrow.dev/oauth/callback`, `app_access` scope map.
- The value is ignored by the current chart and activates when the release from swibrow/goat#62 auto-bumps here. The chart then also derives `PUBLIC_BASE_URL=https://goat.wibrow.dev` from `httpRoute.hostname`.

## Test plan
- [ ] Merge after the goat release lands here
- [ ] `curl -s https://goat.wibrow.dev/.well-known/oauth-authorization-server | jq .issuer` → `https://goat.wibrow.dev`
- [ ] `claude mcp add --transport http goat https://goat.wibrow.dev/mcp` → kanidm login → tools listed