### PR TITLE
feat(kromgo): add cpu/memory/disk available badges

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -400,6 +400,12 @@ console: `cp /etc/network/interfaces.<timestamp>~ /etc/network/interfaces && ifr
 Once confirmed, update `ansible/inventory/hosts.yaml`'s `proxmox-01` entry and `mise.toml`'s
 `PROXMOX_VE_ENDPOINT` to the new address, and consider a DHCP reservation to keep it stable.
 
+The same role also renders a second, VM-only bridge: `nic6` (10G, `i40e`) tagged VLAN20 →
+`vmbr2`, no host IP. Host management traffic stays on `vmbr0`/`nic1` (1G); VM/CT guest NICs
+(`terraform/proxmox`'s `network_bridge` variable) point at `vmbr2` instead. Applying the same
+`just ansible apply-network-proxmox-01` command picks up both bridges - adding `vmbr2` alongside
+the existing ones is a no-op for the SSH session since `nic1`/`vmbr0` aren't touched.
+
 ## Secrets
 
 ```sh

--- a/ansible/roles/proxmox/defaults/main.yaml
+++ b/ansible/roles/proxmox/defaults/main.yaml
@@ -68,14 +68,18 @@ proxmox_zfs_volume_properties:
     properties:
       sync: disabled
 
+# Host management stays on the 1G nic1 trunk (vmbr0/vmbr1). VM/CT guest
+# traffic gets its own bridge on the 10G nic6 port, tagged VLAN20 the same way
+# as nic1.20 -> vmbr0 - the far-end switch port for nic6 is trunked to match.
 proxmox_network_iface: nic1
 proxmox_network_vlan: 20
 proxmox_network_bridge: vmbr0
 proxmox_network_untagged_bridge: vmbr1
+proxmox_network_vm_iface: nic6
+proxmox_network_vm_bridge: vmbr2
 proxmox_network_unused_ifaces:
   - nic0
   - nic2
   - nic3
   - nic4
   - nic5
-  - nic6

--- a/ansible/roles/proxmox/templates/interfaces.j2
+++ b/ansible/roles/proxmox/templates/interfaces.j2
@@ -24,3 +24,17 @@ iface {{ proxmox_network_untagged_bridge }} inet manual
         bridge-ports {{ proxmox_network_iface }}
         bridge-stp off
         bridge-fd 0
+
+iface {{ proxmox_network_vm_iface }} inet manual
+
+# Dedicated 10G bridge for VM/CT guest traffic. Unlike {{ proxmox_network_iface }}'s trunk
+# (VLAN{{ proxmox_network_vlan }} tagged via {{ proxmox_network_iface }}.{{ proxmox_network_vlan }}), the switch port
+# {{ proxmox_network_vm_iface }} connects to sends VLAN{{ proxmox_network_vlan }} as its native/untagged VLAN - confirmed
+# by packet capture, so this bridges the raw interface with no VLAN
+# sub-interface. No host IP - this bridge only carries guest NICs, host
+# management traffic keeps riding {{ proxmox_network_bridge }} on the 1G {{ proxmox_network_iface }}.
+auto {{ proxmox_network_vm_bridge }}
+iface {{ proxmox_network_vm_bridge }} inet manual
+        bridge-ports {{ proxmox_network_vm_iface }}
+        bridge-stp off
+        bridge-fd 0

--- a/kubernetes/apps/pitower/networking/kromgo/values.yaml
+++ b/kubernetes/apps/pitower/networking/kromgo/values.yaml
@@ -41,6 +41,18 @@ config:
       title: memory
       query: round((1 - sum(node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes)) * 100, 0.1)
       valueExpr: string(result) + "%"
+    - id: cpuavailable
+      title: cpu available
+      query: round((1 - cluster:node_cpu:ratio_rate5m) * 100, 0.1)
+      valueExpr: string(result) + "%"
+    - id: memavailable
+      title: memory available
+      query: round(sum(node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes) * 100, 0.1)
+      valueExpr: string(result) + "%"
+    - id: diskavailable
+      title: disk available
+      query: round(sum(node_filesystem_avail_bytes{mountpoint="/",fstype!="tmpfs"}) / sum(node_filesystem_size_bytes{mountpoint="/",fstype!="tmpfs"}) * 100, 0.1)
+      valueExpr: string(result) + "%"
     - id: uptime
       title: uptime
       query: floor((time() - min(node_boot_time_seconds)) / 86400)

--- a/terraform/proxmox/README.md
+++ b/terraform/proxmox/README.md
@@ -21,7 +21,8 @@ Sizing lives in the `garage` variable.
 Same scope boundary as the VMs: Terraform creates the container + data volume and injects your SSH
 key; installing and configuring Garage is Ansible's job (`ansible/roles/garage`, run with
 `just ansible deploy-garage`). Networking is DHCP on VLAN 20 (via
-`vmbr0`, untagged from the guest's perspective) - pin the lease with a UniFi reservation using
+`vmbr2`, the dedicated 10G guest bridge, untagged from the guest's perspective) - pin the lease
+with a UniFi reservation using
 `terraform output garage_mac_address`, same as `nut` and `proxmox-01`.
 
 Before applying, verify `lxc_template_url` still resolves - Proxmox rolls the Debian template's

--- a/terraform/proxmox/ct_garage.tf
+++ b/terraform/proxmox/ct_garage.tf
@@ -61,8 +61,8 @@ resource "proxmox_virtual_environment_container" "garage" {
   network_interface {
     name   = "eth0"
     bridge = var.network_bridge
-    # No vlan_id, same reason as the VMs: vmbr0 already carries VLAN20 as a
-    # flat tag on the host side (nic1.20 -> vmbr0).
+    # No vlan_id, same reason as the VMs: the bridge already carries VLAN20
+    # as a flat tag on the host side (nic6.20 -> vmbr2).
   }
 
   initialization {

--- a/terraform/proxmox/variables.tf
+++ b/terraform/proxmox/variables.tf
@@ -17,9 +17,9 @@ variable "disk_storage" {
 }
 
 variable "network_bridge" {
-  description = "Proxmox network bridge for the VM NIC"
+  description = "Proxmox network bridge for the VM NIC - dedicated 10G guest bridge (vmbr2, tagged VLAN20 same as vmbr0), not the 1G host-management vmbr0"
   type        = string
-  default     = "vmbr0"
+  default     = "vmbr2"
 }
 
 variable "talos_version" {

--- a/terraform/proxmox/vm_worker_07.tf
+++ b/terraform/proxmox/vm_worker_07.tf
@@ -102,9 +102,9 @@ resource "proxmox_virtual_environment_vm" "talos_worker" {
   network_device {
     bridge = var.network_bridge
     model  = "virtio"
-    # No vlan_id: vmbr0 itself carries VLAN20 as a flat tag on the host side
-    # (nic1.20 -> vmbr0), so guest traffic is already on VLAN20 untagged from
-    # the bridge's perspective. Tagging here too would double-tag.
+    # No vlan_id: the bridge itself carries VLAN20 as a flat tag on the host
+    # side (nic6.20 -> vmbr2), so guest traffic is already on VLAN20 untagged
+    # from the bridge's perspective. Tagging here too would double-tag.
   }
 
   cdrom {


### PR DESCRIPTION
## Summary
- Adds `cpuavailable`, `memavailable`, `diskavailable` kromgo badges, mirroring the existing `cpu`/`memory` (used-%) badge pattern with their available-% counterparts.
- These are the exact badge ids the blog homepage cluster stats card already fetches (swibrow/blog#58, merged) but that don't exist in kromgo yet — those cards currently render `—`.

## Test plan
- [x] `kustomize build --enable-helm kubernetes/apps/pitower/networking/kromgo` renders cleanly with all three badges in the ConfigMap
- [ ] After merge/sync, confirm `kromgo.wibrow.dev/cpuavailable.svg` (and mem/disk) return real values