### PR TITLE
fix(proxmox): keep the runners disk block last, out of interface order

### DIFF
--- a/terraform/proxmox/vm_worker_07.tf
+++ b/terraform/proxmox/vm_worker_07.tf
@@ -115,19 +115,23 @@ resource "proxmox_virtual_environment_vm" "talos_worker" {
     # disks by size band and 400-500GiB already belongs to scratch (scsi1).
     # Growing past 400GiB means widening both selectors in the same change.
     #
-    # scsi4, NOT the scsi2 slot this disk used to occupy. The provider keys
-    # `disk` blocks by interface order, not by their order in this file, and
-    # diffs them positionally against state. State holds [scsi0, scsi1, scsi3],
-    # so introducing a scsi2 sorts it into index 2 and every later disk shifts
-    # down: terraform then plans an in-place rewrite of the media disk
+    # THIS BLOCK MUST STAY LAST. `disk` is a list, and terraform diffs list
+    # elements by position - the position in this file, not the interface
+    # number. State holds [scsi0, scsi1, scsi3], so a new block declared in
+    # scsi-slot order (ahead of media's scsi3) lands at index 2 and shifts
+    # media to index 3. Terraform then reads that as "index 2 changed from
+    # media to runners" and plans an in-place rewrite of the media disk
     # (scsi3 -> scsi2, 1200 -> 350, datastore media -> runners) plus a
-    # replacement 1200GiB media disk. That is the Immich photo library. It was
-    # planned and auto-applied on 2026-08-11 and only missed destroying the
-    # library because Proxmox errored on the new zvol's device link partway
-    # through. Moving this block around the file does not help - only an
-    # interface that sorts after every existing one does.
+    # replacement 1200GiB media disk. That is the Immich photo library.
+    #
+    # It was planned and auto-applied on 2026-08-11, and only missed
+    # destroying the library because Proxmox errored on the new zvol's device
+    # link partway through - after writing a phantom scsi2 disk into state and
+    # blanking media's path_in_datastore, which had to be repaired by hand.
+    # Appended last, the first three blocks line up with state and this one is
+    # a pure add.
     datastore_id = "runners"
-    interface    = "scsi4"
+    interface    = "scsi2"
     size         = 350
     iothread     = true
     discard      = "on"

--- a/terraform/proxmox/vm_worker_07.tf
+++ b/terraform/proxmox/vm_worker_07.tf
@@ -115,14 +115,19 @@ resource "proxmox_virtual_environment_vm" "talos_worker" {
     # disks by size band and 400-500GiB already belongs to scratch (scsi1).
     # Growing past 400GiB means widening both selectors in the same change.
     #
-    # THIS BLOCK MUST STAY LAST, out of interface order. The provider matches
-    # disk blocks by position, not by `interface`, so putting scsi2 in slot
-    # order ahead of scsi3 makes terraform plan an in-place rewrite of the
-    # media disk (scsi3 -> scsi2, 1200 -> 350, datastore media -> runners) and
-    # a fresh 1200GiB media disk after it. That plan ran on 2026-08-11 and only
-    # missed destroying the Immich library because Proxmox errored partway.
+    # scsi4, NOT the scsi2 slot this disk used to occupy. The provider keys
+    # `disk` blocks by interface order, not by their order in this file, and
+    # diffs them positionally against state. State holds [scsi0, scsi1, scsi3],
+    # so introducing a scsi2 sorts it into index 2 and every later disk shifts
+    # down: terraform then plans an in-place rewrite of the media disk
+    # (scsi3 -> scsi2, 1200 -> 350, datastore media -> runners) plus a
+    # replacement 1200GiB media disk. That is the Immich photo library. It was
+    # planned and auto-applied on 2026-08-11 and only missed destroying the
+    # library because Proxmox errored on the new zvol's device link partway
+    # through. Moving this block around the file does not help - only an
+    # interface that sorts after every existing one does.
     datastore_id = "runners"
-    interface    = "scsi2"
+    interface    = "scsi4"
     size         = 350
     iothread     = true
     discard      = "on"

--- a/terraform/proxmox/vm_worker_07.tf
+++ b/terraform/proxmox/vm_worker_07.tf
@@ -87,23 +87,6 @@ resource "proxmox_virtual_environment_vm" "talos_worker" {
   }
 
   disk {
-    # GitHub-runner scratch on the `runners` zpool - now a single 500GB Samsung
-    # 850 EVO in bay 9, not the old 4x 830 stripe. Consumer TLC with no PLP and
-    # no redundancy, and the pool runs sync=disabled, so this holds only
-    # per-job throwaway data (runner work dirs + dind's /var/lib/docker).
-    #
-    # 350GiB, not the pool's full ~450GiB: the Talos UserVolumeConfig picks
-    # disks by size band and 400-500GiB already belongs to scratch (scsi1).
-    # Growing past 400GiB means widening both selectors in the same change.
-    datastore_id = "runners"
-    interface    = "scsi2"
-    size         = 350
-    iothread     = true
-    discard      = "on"
-    ssd          = true
-  }
-
-  disk {
     # The Immich photo library, on the `media` zpool (4x 600GB 10K SAS, RAIDZ1,
     # bays 4-7). 1200GiB of the pool's 1566GiB usable, leaving headroom so the
     # pool never runs past ~77% - RAIDZ degrades badly when close to full. The
@@ -120,6 +103,30 @@ resource "proxmox_virtual_environment_vm" "talos_worker" {
     size         = 1200
     iothread     = true
     discard      = "on"
+  }
+
+  disk {
+    # GitHub-runner scratch on the `runners` zpool - now a single 500GB Samsung
+    # 850 EVO in bay 9, not the old 4x 830 stripe. Consumer TLC with no PLP and
+    # no redundancy, and the pool runs sync=disabled, so this holds only
+    # per-job throwaway data (runner work dirs + dind's /var/lib/docker).
+    #
+    # 350GiB, not the pool's full ~450GiB: the Talos UserVolumeConfig picks
+    # disks by size band and 400-500GiB already belongs to scratch (scsi1).
+    # Growing past 400GiB means widening both selectors in the same change.
+    #
+    # THIS BLOCK MUST STAY LAST, out of interface order. The provider matches
+    # disk blocks by position, not by `interface`, so putting scsi2 in slot
+    # order ahead of scsi3 makes terraform plan an in-place rewrite of the
+    # media disk (scsi3 -> scsi2, 1200 -> 350, datastore media -> runners) and
+    # a fresh 1200GiB media disk after it. That plan ran on 2026-08-11 and only
+    # missed destroying the Immich library because Proxmox errored partway.
+    datastore_id = "runners"
+    interface    = "scsi2"
+    size         = 350
+    iothread     = true
+    discard      = "on"
+    ssd          = true
   }
 
   network_device {


### PR DESCRIPTION
Follow-up to bae5635f, which is currently in main and unsafe to apply.

The bpg/proxmox provider matches `disk` blocks by position, not by `interface`. Declaring the new scsi2 block in slot order (ahead of the existing scsi3 media disk) shifted media down a position, so terraform planned:

```
~ disk {  scsi3 -> scsi2,  1200 -> 350,  datastore media -> runners  }
+ disk {  scsi3, media, 1200  }
```

That first block is the Immich photo library. The 2026-08-11 apply started `Modifying...` and only failed partway, on `no zvol device link for 'vm-200-disk-0' found after 10 sec` — nothing was actually changed (`qm config 200` and `media/vm-200-disk-0` verified intact afterwards).

This moves the scsi2 block to the end of the file so the first three blocks match existing state positionally and the new one is a pure add.

Opened as a PR rather than a push to main specifically to get the plan-only job: pushes to `terraform/proxmox/**` apply with `auto_approve: true`, and this plan needs eyes on it first.

**Merge only if the plan reads `1 to add, 0 to change, 0 to destroy`.**